### PR TITLE
Add Weave Router submission to leaderboard

### DIFF
--- a/src/data/routerData.ts
+++ b/src/data/routerData.ts
@@ -194,7 +194,7 @@ const routersWithRanks = rawRouterData.map(router => {
   };
 });
 
-routersWithRanks.sort((a, b) => b.metrics.arenaScore - a.metrics.arenaScore);
+routersWithRanks.sort((a, b) => b._averageScore - a._averageScore);
 routersWithRanks.forEach((router, index) => {
   router.metrics.overallRank = index + 1;
 });

--- a/src/data/routerData.ts
+++ b/src/data/routerData.ts
@@ -194,7 +194,7 @@ const routersWithRanks = rawRouterData.map(router => {
   };
 });
 
-routersWithRanks.sort((a, b) => b._averageScore - a._averageScore);
+routersWithRanks.sort((a, b) => b.metrics.arenaScore - a.metrics.arenaScore);
 routersWithRanks.forEach((router, index) => {
   router.metrics.overallRank = index + 1;
 });

--- a/src/data/routerMetrics/leaderboard.json
+++ b/src/data/routerMetrics/leaderboard.json
@@ -1,5 +1,16 @@
 [
   {
+    "Router Name": "Weave Router",
+    "Arena Score": 74.61,
+    "Optimal Selection Score": 1.38,
+    "Optimal Cost Score": 12.27,
+    "Optimal Acc. Score": 100.00,
+    "Robustness Score": 79.05,
+    "Latency Score": null,
+    "Accuracy": 78.43,
+    "Cost per 1k": 0.92
+  },
+  {
     "Router Name": "R2-Router",
     "Arena Score": 71.60,
     "Optimal Selection Score": 32.38,

--- a/src/data/routers.json
+++ b/src/data/routers.json
@@ -1,4 +1,26 @@
 {
+  "Weave Router": {
+    "name": "Weave Router",
+    "type": "open-source",
+    "description": "Cluster-routing over a 12-model BYOK pool spanning Anthropic, OpenAI, Google, and OpenRouter providers. Embeds each prompt, scores against per-cluster model rankings, and selects the cost-quality optimum via an alpha-blended score.",
+    "affiliation": "Weave",
+    "modelPool": [
+      "claude-opus-4-7",
+      "claude-sonnet-4-5",
+      "claude-haiku-4-5",
+      "gpt-5.5",
+      "gpt-5.4-mini",
+      "gpt-4.1",
+      "gemini-3.1-pro-preview",
+      "gemini-3.1-flash-lite-preview",
+      "deepseek/deepseek-v4-pro",
+      "deepseek/deepseek-v4-flash",
+      "qwen/qwen3.5-flash-02-23",
+      "moonshotai/kimi-k2.5"
+    ],
+    "websiteUrl": "https://weaverouter.com",
+    "githubUrl": "https://github.com/workweave/router"
+  },
   "R2-Router": {
     "name": "R2-Router",
     "type": "open-source",

--- a/src/data/routers.yaml
+++ b/src/data/routers.yaml
@@ -1,3 +1,24 @@
+Weave Router:
+  name: Weave Router
+  type: open-source
+  description: Cluster-routing over a 12-model BYOK pool spanning Anthropic, OpenAI, Google, and OpenRouter providers. Embeds each prompt, scores against per-cluster model rankings, and selects the cost-quality optimum via an alpha-blended score.
+  affiliation: Weave
+  modelPool:
+    - claude-opus-4-7
+    - claude-sonnet-4-5
+    - claude-haiku-4-5
+    - gpt-5.5
+    - gpt-5.4-mini
+    - gpt-4.1
+    - gemini-3.1-pro-preview
+    - gemini-3.1-flash-lite-preview
+    - deepseek/deepseek-v4-pro
+    - deepseek/deepseek-v4-flash
+    - qwen/qwen3.5-flash-02-23
+    - moonshotai/kimi-k2.5
+  websiteUrl: https://weaverouter.com
+  githubUrl: https://github.com/workweave/router
+
 RouterDC:
   name: RouterDC
   type: open-source


### PR DESCRIPTION
Adds the Weave Router (v0.27) entry to the leaderboard data, mirroring
the upstream RouterArena README/PR #92 submission. Switches the overall
rank computation to sort by Arena Score so site ranking matches the
README ordering.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>