### PR TITLE
Update Weave Router scores to v0.62 (#1)

### DIFF
--- a/src/data/routerMetrics/leaderboard.json
+++ b/src/data/routerMetrics/leaderboard.json
@@ -12,14 +12,14 @@
   },
   {
     "Router Name": "Weave Router",
-    "Arena Score": 74.61,
-    "Optimal Selection Score": 1.27,
-    "Optimal Cost Score": 12.1,
-    "Optimal Acc. Score": 89.56,
-    "Robustness Score": 79.05,
+    "Arena Score": 76.09,
+    "Optimal Selection Score": 5.6,
+    "Optimal Cost Score": 17.19,
+    "Optimal Acc. Score": 89.21,
+    "Robustness Score": 79.76,
     "Latency Score": null,
-    "Accuracy": 78.43,
-    "Cost per 1k": 0.92
+    "Accuracy": 79.32,
+    "Cost per 1k": 0.61
   },
   {
     "Router Name": "R2-Router",

--- a/src/data/routers.json
+++ b/src/data/routers.json
@@ -15,21 +15,16 @@
   "Weave Router": {
     "name": "Weave Router",
     "type": "open-source",
-    "description": "Cluster-routing over a 12-model BYOK pool spanning Anthropic, OpenAI, Google, and OpenRouter providers. Embeds each prompt, scores against per-cluster model rankings, and selects the cost-quality optimum via an alpha-blended score.",
+    "description": "Cluster-routing (v0.62) over a 7-model BYOK pool spanning Anthropic, OpenAI, Google, and OpenRouter providers. Embeds each prompt with Jina v2 INT8 ONNX (768-dim), runs top-p=4 cluster sum against per-cluster rankings trained on the RouterArena full split with k=160 clusters, then selects the cost-quality optimum via an alpha-blended score (alpha=0.25).",
     "affiliation": "Weave",
     "modelPool": [
       "claude-opus-4-7",
-      "claude-sonnet-4-5",
-      "claude-haiku-4-5",
       "gpt-5.5",
-      "gpt-5.4-mini",
-      "gpt-4.1",
       "gemini-3.1-pro-preview",
       "gemini-3.1-flash-lite-preview",
       "deepseek/deepseek-v4-pro",
       "deepseek/deepseek-v4-flash",
-      "qwen/qwen3.5-flash-02-23",
-      "moonshotai/kimi-k2.5"
+      "qwen/qwen3-235b-a22b-2507"
     ],
     "websiteUrl": "https://weaverouter.com",
     "githubUrl": "https://github.com/workweave/router"

--- a/src/data/routers.yaml
+++ b/src/data/routers.yaml
@@ -1,21 +1,16 @@
 Weave Router:
   name: Weave Router
   type: open-source
-  description: Cluster-routing over a 12-model BYOK pool spanning Anthropic, OpenAI, Google, and OpenRouter providers. Embeds each prompt, scores against per-cluster model rankings, and selects the cost-quality optimum via an alpha-blended score.
+  description: Cluster-routing (v0.62) over a 7-model BYOK pool spanning Anthropic, OpenAI, Google, and OpenRouter providers. Embeds each prompt with Jina v2 INT8 ONNX (768-dim), runs top-p=4 cluster sum against per-cluster rankings trained on the RouterArena full split with k=160 clusters, then selects the cost-quality optimum via an alpha-blended score (alpha=0.25).
   affiliation: Weave
   modelPool:
     - claude-opus-4-7
-    - claude-sonnet-4-5
-    - claude-haiku-4-5
     - gpt-5.5
-    - gpt-5.4-mini
-    - gpt-4.1
     - gemini-3.1-pro-preview
     - gemini-3.1-flash-lite-preview
     - deepseek/deepseek-v4-pro
     - deepseek/deepseek-v4-flash
-    - qwen/qwen3.5-flash-02-23
-    - moonshotai/kimi-k2.5
+    - qwen/qwen3-235b-a22b-2507
   websiteUrl: https://weaverouter.com
   githubUrl: https://github.com/workweave/router
 


### PR DESCRIPTION
Update the Weave Router entry in \`src/data/routerMetrics/leaderboard.json\` with v0.62 results.

Submission PR: [RouteWorks/RouterArena#102](https://github.com/RouteWorks/RouterArena/pull/102)