### PR TITLE
Add OrcaRouter-Adaptive submission to leaderboard

### DIFF
--- a/src/data/routerMetrics/leaderboard.json
+++ b/src/data/routerMetrics/leaderboard.json
@@ -11,6 +11,17 @@
     "Cost per 1k": 0.18
   },
   {
+    "Router Name": "OrcaRouter-Adaptive",
+    "Arena Score": 72.08,
+    "Optimal Selection Score": null,
+    "Optimal Cost Score": null,
+    "Optimal Acc. Score": null,
+    "Robustness Score": 22.62,
+    "Latency Score": null,
+    "Accuracy": 75.54,
+    "Cost per 1k": 1.0
+  },
+  {
     "Router Name": "R2-Router",
     "Arena Score": 71.6,
     "Optimal Selection Score": 24.51,

--- a/src/data/routers.json
+++ b/src/data/routers.json
@@ -1,4 +1,23 @@
 {
+  "OrcaRouter-Adaptive": {
+    "name": "OrcaRouter-Adaptive",
+    "type": "closed-source",
+    "description": "LinUCB contextual bandit with embedding features routing across a 10-model pool spanning Anthropic, Google, OpenAI, DeepSeek, and Alibaba.",
+    "affiliation": "",
+    "modelPool": [
+      "anthropic/claude-haiku-4-5-20251001",
+      "anthropic/claude-sonnet-4",
+      "google/gemini-2.5-flash-lite",
+      "google/gemini-2.5-flash",
+      "openai/gpt-4o-mini",
+      "openai/gpt-5-mini",
+      "deepseek/deepseek-chat",
+      "deepseek/deepseek-reasoner",
+      "alibaba/qwen3-235b-a22b-instruct-2507",
+      "alibaba/qwen3-30b-a3b-instruct-2507"
+    ],
+    "websiteUrl": "https://www.orcarouter.ai/"
+  },
   "Sqwish Router": {
     "name": "Sqwish Router",
     "type": "closed-source",

--- a/src/data/routers.yaml
+++ b/src/data/routers.yaml
@@ -1,3 +1,21 @@
+OrcaRouter-Adaptive:
+  name: OrcaRouter-Adaptive
+  type: closed-source
+  description: LinUCB contextual bandit with embedding features routing across a 10-model pool spanning Anthropic, Google, OpenAI, DeepSeek, and Alibaba.
+  affiliation: ''
+  modelPool:
+    - anthropic/claude-haiku-4-5-20251001
+    - anthropic/claude-sonnet-4
+    - google/gemini-2.5-flash-lite
+    - google/gemini-2.5-flash
+    - openai/gpt-4o-mini
+    - openai/gpt-5-mini
+    - deepseek/deepseek-chat
+    - deepseek/deepseek-reasoner
+    - alibaba/qwen3-235b-a22b-instruct-2507
+    - alibaba/qwen3-30b-a3b-instruct-2507
+  websiteUrl: https://www.orcarouter.ai/
+
 # --- Weave Router temporarily removed from the public leaderboard. ---
 # Restore by uncommenting this block AND re-adding the matching entries
 # in leaderboard.json, routers.json, and category_scores.json (key:


### PR DESCRIPTION
## Summary

Adds the **OrcaRouter-Adaptive** entry to the leaderboard data, mirroring the upstream RouterArena submission merged in [PR #104](https://github.com/RouterArena/RouterArena/pull/104) (predictions), [PR #108](https://github.com/RouterArena/RouterArena/pull/108) (README rank), and [PR #110](https://github.com/RouterArena/RouterArena/pull/110) (website link).

## Submission

- **Router:** OrcaRouter-Adaptive
- **Approach:** LinUCB contextual bandit with embedding features
- **Model pool (10):** Anthropic claude-haiku/sonnet-4, Google gemini-2.5-flash/-lite, OpenAI gpt-4o-mini/gpt-5-mini, DeepSeek chat/reasoner, Alibaba qwen3-235b/30b
- **Website:** https://www.orcarouter.ai/
- **Type:** closed-source (paper + GitHub may be added in a follow-up)

## Bot-reported metrics

| Metric | Value |
|---|---|
| Arena Score | 72.08 |
| Accuracy | 75.54 |
| Cost / 1K Queries | \$1.00 |
| Robustness | 22.62 |
| Optimal Selection | — |
| Optimal Cost | — |
| Optimal Accuracy | — |
| Latency | — |

The three optimality columns and latency are dashed — the submitted prediction file did not include `for_optimality=True` entries, same convention as GPT-5 and Azure-Model-Router. May be filled in a follow-up submission.

## Files touched

- `src/data/routerMetrics/leaderboard.json` — new row, sorted by Arena Score (between Sqwish 75.27 and R2-Router 71.6)
- `src/data/routers.json` — new metadata entry
- `src/data/routers.yaml` — new metadata entry

No category_scores.json change — `routerData.ts` auto-synthesizes the entry from the leaderboard row.

## Test plan

- [x] `python -c "json.load(...)"` on both edited JSON files — parses clean