### PR TITLE
Re-add Weave Router (v0.54) and refresh Azure-Model-Router metrics

### DIFF
--- a/src/data/routerMetrics/leaderboard.json
+++ b/src/data/routerMetrics/leaderboard.json
@@ -11,6 +11,17 @@
     "Cost per 1k": 0.18
   },
   {
+    "Router Name": "Weave Router",
+    "Arena Score": 72.82,
+    "Optimal Selection Score": null,
+    "Optimal Cost Score": null,
+    "Optimal Acc. Score": null,
+    "Robustness Score": 100.0,
+    "Latency Score": null,
+    "Accuracy": 76.32,
+    "Cost per 1k": 0.94
+  },
+  {
     "Router Name": "R2-Router",
     "Arena Score": 71.6,
     "Optimal Selection Score": 24.51,
@@ -56,14 +67,14 @@
   },
   {
     "Router Name": "azure",
-    "Arena Score": 66.66,
-    "Optimal Selection Score": 22.52,
-    "Optimal Cost Score": 46.322,
-    "Optimal Acc. Score": 81.96,
-    "Robustness Score": 54.07,
+    "Arena Score": 71.87,
+    "Optimal Selection Score": null,
+    "Optimal Cost Score": null,
+    "Optimal Acc. Score": null,
+    "Robustness Score": 71.43,
     "Latency Score": null,
-    "Accuracy": 68.09,
-    "Cost per 1k": 0.54
+    "Accuracy": 72.82,
+    "Cost per 1k": 0.22
   },
   {
     "Router Name": "nirt_bert",

--- a/src/data/routers.json
+++ b/src/data/routers.json
@@ -12,6 +12,22 @@
       "deepseek/deepseek-v4-flash"
     ]
   },
+  "Weave Router": {
+    "name": "Weave Router",
+    "type": "open-source",
+    "description": "Weave Router (v0.54): 6-model cluster routing trained only on OpenRouterBench labels + Artificial Analysis quality priors. No RouterArena prompts in any training signal.",
+    "affiliation": "Weave",
+    "modelPool": [
+      "deepseek/deepseek-v4-flash",
+      "deepseek/deepseek-v4-pro",
+      "gemini-3.1-flash-lite-preview",
+      "gemini-3.1-pro-preview",
+      "Qwen/Qwen3-Coder-Next",
+      "qwen/qwen3-next-80b-a3b-instruct"
+    ],
+    "websiteUrl": "https://workweave.ai",
+    "githubUrl": "https://github.com/workweave/router"
+  },
   "R2-Router": {
     "name": "R2-Router",
     "type": "open-source",

--- a/src/data/routers.yaml
+++ b/src/data/routers.yaml
@@ -1,23 +1,17 @@
-# --- Weave Router temporarily removed from the public leaderboard. ---
-# Restore by uncommenting this block AND re-adding the matching entries
-# in leaderboard.json, routers.json, and category_scores.json (key:
-# "weave-router"). flip_labels/flip_labels_weave-router.json is kept.
-#
-# Weave Router:
-#   name: Weave Router
-#   type: open-source
-#   description: Cluster-routing (v0.62) over a 7-model BYOK pool spanning Anthropic, OpenAI, Google, and OpenRouter providers. Embeds each prompt with Jina v2 INT8 ONNX (768-dim), runs top-p=4 cluster sum against per-cluster rankings trained on the RouterArena full split with k=160 clusters, then selects the cost-quality optimum via an alpha-blended score (alpha=0.25).
-#   affiliation: Weave
-#   modelPool:
-#     - claude-opus-4-7
-#     - gpt-5.5
-#     - gemini-3.1-pro-preview
-#     - gemini-3.1-flash-lite-preview
-#     - deepseek/deepseek-v4-pro
-#     - deepseek/deepseek-v4-flash
-#     - qwen/qwen3-235b-a22b-2507
-#   websiteUrl: https://weaverouter.com
-#   githubUrl: https://github.com/workweave/router
+Weave Router:
+  name: Weave Router
+  type: open-source
+  description: 'Weave Router (v0.54): 6-model cluster routing trained only on OpenRouterBench labels + Artificial Analysis quality priors. No RouterArena prompts in any training signal.'
+  affiliation: Weave
+  modelPool:
+    - deepseek/deepseek-v4-flash
+    - deepseek/deepseek-v4-pro
+    - gemini-3.1-flash-lite-preview
+    - gemini-3.1-pro-preview
+    - Qwen/Qwen3-Coder-Next
+    - qwen/qwen3-next-80b-a3b-instruct
+  websiteUrl: https://workweave.ai
+  githubUrl: https://github.com/workweave/router
 
 RouterDC:
   name: RouterDC


### PR DESCRIPTION
Syncs with RouterArena main after the no-training-policy retrain and the PR #98/#107 Azure re-evaluation.

- Weave Router: re-added at rank 2 (RouterArena PR #109). v0.54 "clean retrain" — 6-model cluster routing trained only on OpenRouterBench labels + Artificial Analysis quality priors, no RouterArena prompts. Arena 72.82, Acc 76.32, Cost $0.94, Robustness 100.00; optimality metrics are blank (submission has no for_optimality entries).
- Azure-Model-Router: refreshed to Arena 71.87, Acc 72.82, Cost $0.22, Robustness 71.43; optimality cleared to match README.

Weave per-domain category_scores fall back to synthetic (no v0.54 prediction file imported); the stale flip_labels_weave-router.json is left in place. Metadata (model pool, description, links) updated to v0.54.