### PR TITLE
Sync leaderboard data from RouterArena

### DIFF
--- a/src/data/flip_labels/flip_labels_hybrid-router.json
+++ b/src/data/flip_labels/flip_labels_hybrid-router.json
@@ -1,0 +1,1682 @@
+[
+  {
+    "global index": "AIME_112",
+    "flip": 0
+  },
+  {
+    "global index": "AIME_58",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_12",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_123",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_16",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_182",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_230",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_293",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_349",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_378",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_443",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_496",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_631",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_646",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_659",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_676",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_685",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_689",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_702",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_713",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_98",
+    "flip": 0
+  },
+  {
+    "global index": "AsDiv_1165",
+    "flip": 0
+  },
+  {
+    "global index": "AsDiv_1347",
+    "flip": 0
+  },
+  {
+    "global index": "AsDiv_472",
+    "flip": 0
+  },
+  {
+    "global index": "AsDiv_733",
+    "flip": 0
+  },
+  {
+    "global index": "ChessInstruct_0",
+    "flip": 0
+  },
+  {
+    "global index": "ChessInstruct_107",
+    "flip": 0
+  },
+  {
+    "global index": "ChessInstruct_144",
+    "flip": 0
+  },
+  {
+    "global index": "ChessInstruct_42",
+    "flip": 0
+  },
+  {
+    "global index": "ChessInstruct_58",
+    "flip": 0
+  },
+  {
+    "global index": "ChessInstruct_71",
+    "flip": 0
+  },
+  {
+    "global index": "ChessInstruct_84",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_commonsense_28",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_commonsense_51",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_commonsense_6",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_commonsense_62",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_commonsense_70",
+    "flip": 1
+  },
+  {
+    "global index": "Ethics_commonsense_85",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_commonsense_90",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_deontology_0",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_deontology_2",
+    "flip": 1
+  },
+  {
+    "global index": "Ethics_deontology_31",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_deontology_32",
+    "flip": 1
+  },
+  {
+    "global index": "Ethics_deontology_56",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_justice_1",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_justice_45",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_justice_76",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_justice_84",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_virtue_14",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_virtue_26",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_virtue_30",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_virtue_48",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_virtue_51",
+    "flip": 0
+  },
+  {
+    "global index": "FinQA_149",
+    "flip": 0
+  },
+  {
+    "global index": "FinQA_208",
+    "flip": 0
+  },
+  {
+    "global index": "FinQA_56",
+    "flip": 0
+  },
+  {
+    "global index": "FinQA_60",
+    "flip": 0
+  },
+  {
+    "global index": "GSM8K_43",
+    "flip": 0
+  },
+  {
+    "global index": "GeoBench_1002",
+    "flip": 0
+  },
+  {
+    "global index": "GeoBench_1094",
+    "flip": 0
+  },
+  {
+    "global index": "GeoBench_1102",
+    "flip": 0
+  },
+  {
+    "global index": "GeoBench_1113",
+    "flip": 0
+  },
+  {
+    "global index": "GeoBench_124",
+    "flip": 0
+  },
+  {
+    "global index": "GeoBench_1243",
+    "flip": 0
+  },
+  {
+    "global index": "GeoBench_30",
+    "flip": 0
+  },
+  {
+    "global index": "GeoBench_502",
+    "flip": 0
+  },
+  {
+    "global index": "GeoBench_526",
+    "flip": 0
+  },
+  {
+    "global index": "GeoBench_591",
+    "flip": 0
+  },
+  {
+    "global index": "GeoBench_766",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_87",
+    "flip": 0
+  },
+  {
+    "global index": "GeoBench_915",
+    "flip": 0
+  },
+  {
+    "global index": "GeoBench_944",
+    "flip": 0
+  },
+  {
+    "global index": "GeoBench_968",
+    "flip": 0
+  },
+  {
+    "global index": "GeoGraphyData_100k_27",
+    "flip": 0
+  },
+  {
+    "global index": "GeoGraphyData_100k_42",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_105",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_114",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_118",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_131",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_136",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_181",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_237",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_271",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_350",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_386",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_405",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_43",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_431",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_437",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_476",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_485",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_49",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_491",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_499",
+    "flip": 0
+  },
+  {
+    "global index": "MATH_108",
+    "flip": 0
+  },
+  {
+    "global index": "MATH_442",
+    "flip": 0
+  },
+  {
+    "global index": "MATH_53",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_biology_2808",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_biology_2912",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_biology_2980",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_biology_2985",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_biology_3188",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_biology_3215",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_biology_3225",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_business_226",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_business_294",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_business_378",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_business_430",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_business_503",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_business_507",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_business_6",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_business_784",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_chemistry_3796",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_chemistry_3837",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_chemistry_3974",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_chemistry_4067",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_chemistry_4407",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9086",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9110",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9136",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9138",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9149",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9200",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9212",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9239",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9264",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9285",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9289",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9414",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9415",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9430",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9452",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9471",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9475",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_economics_5769",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_economics_5907",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_economics_5931",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_economics_5965",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_economics_6114",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_economics_6122",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_economics_6135",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_economics_6325",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_economics_6353",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10076",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10125",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10179",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10195",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10199",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10298",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10342",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10395",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10428",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10432",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10473",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10537",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10701",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10823",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10864",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_health_4885",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_health_4973",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_health_5093",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_health_5144",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_health_5214",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_health_5215",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_health_5261",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_health_5473",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_health_5514",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4486",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4490",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4497",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4509",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4517",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4523",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4605",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4629",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4638",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4717",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4749",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4752",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4774",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4810",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4833",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4836",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4841",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_law_1007",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_law_1031",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_law_1386",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_law_1462",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_law_1484",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_law_1518",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_law_1818",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_law_806",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_law_899",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_math_6429",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_math_6526",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_math_6623",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_math_6848",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_math_7101",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_math_7249",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_math_7284",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_math_7451",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_math_7577",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_philosophy_9510",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_philosophy_9536",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_philosophy_9663",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_philosophy_9672",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_philosophy_9943",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_physics_7773",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_physics_7887",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_physics_7893",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_physics_8888",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_physics_9017",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_psychology_2005",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_psychology_2186",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_psychology_2329",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_psychology_2406",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_psychology_2420",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_psychology_2450",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_psychology_2457",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_psychology_2524",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_formal_logic_121",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_formal_logic_16",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_formal_logic_32",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_formal_logic_63",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_formal_logic_7",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_formal_logic_70",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_formal_logic_85",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_management_4",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_management_41",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_management_77",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_management_91",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_management_93",
+    "flip": 0
+  },
+  {
+    "global index": "MathQA_158",
+    "flip": 0
+  },
+  {
+    "global index": "MathQA_1742",
+    "flip": 0
+  },
+  {
+    "global index": "MathQA_202",
+    "flip": 0
+  },
+  {
+    "global index": "MathQA_2092",
+    "flip": 0
+  },
+  {
+    "global index": "MathQA_2102",
+    "flip": 0
+  },
+  {
+    "global index": "MathQA_2851",
+    "flip": 0
+  },
+  {
+    "global index": "MathQA_827",
+    "flip": 0
+  },
+  {
+    "global index": "MathQA_84",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_1005",
+    "flip": 1
+  },
+  {
+    "global index": "MedMCQA_1054",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_1298",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_1309",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_1362",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_145",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_2010",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_2323",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_2366",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_2581",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_511",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_59",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_643",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_853",
+    "flip": 0
+  },
+  {
+    "global index": "MusicTheoryBench_126",
+    "flip": 0
+  },
+  {
+    "global index": "MusicTheoryBench_14",
+    "flip": 0
+  },
+  {
+    "global index": "MusicTheoryBench_147",
+    "flip": 0
+  },
+  {
+    "global index": "MusicTheoryBench_152",
+    "flip": 0
+  },
+  {
+    "global index": "MusicTheoryBench_188",
+    "flip": 0
+  },
+  {
+    "global index": "MusicTheoryBench_189",
+    "flip": 0
+  },
+  {
+    "global index": "MusicTheoryBench_240",
+    "flip": 0
+  },
+  {
+    "global index": "MusicTheoryBench_33",
+    "flip": 0
+  },
+  {
+    "global index": "MusicTheoryBench_337",
+    "flip": 0
+  },
+  {
+    "global index": "MusicTheoryBench_340",
+    "flip": 0
+  },
+  {
+    "global index": "MusicTheoryBench_70",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_131",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_1683",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_2474",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_2820",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_3282",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_4102",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_4128",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_4347",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_4540",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_5022",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_5259",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_533",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_5894",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_6829",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_7678",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_7964",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_8215",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_8598",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_927",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Animals_2545",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Animals_262",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Art_1429",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Celebrities_1078",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Celebrities_1456",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Celebrities_3577",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Celebrities_3968",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_1178",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_1807",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_1957",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_2181",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_3404",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_3727",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_4019",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Geography_2099",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Geography_2346",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Geography_3880",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Geography_792",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_History_1162",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_History_2026",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_History_3712",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_History_3902",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Science & Nature_1175",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Science & Nature_1560",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Science & Nature_3716",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Science & Nature_476",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Sports_2289",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Vehicles_1173",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Vehicles_1419",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Vehicles_2519",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Vehicles_3234",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_0",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_154",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_18",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_238",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_250",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_337",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_362",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_437",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_510",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_520",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_575",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_582",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_588",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_610",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_63",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_643",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_687",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_722",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_73",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_755",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_8",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_81",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_854",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_905",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Fine Arts_1212",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Fine Arts_1702",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Fine Arts_828",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Fine Arts_865",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Geography_1023",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Geography_1555",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Geography_304",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_History_1084",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_History_1154",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_History_433",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_History_473",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_History_926",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Literature_1045",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Literature_1073",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Literature_1239",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Literature_1326",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Literature_1727",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Literature_1843",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Literature_386",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Literature_408",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Literature_475",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Literature_833",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Philosophy_1270",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Philosophy_499",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Philosophy_91",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Science_1360",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Science_1473",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Science_308",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Science_619",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Social Science_1847",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Social Science_2",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Social Science_77",
+    "flip": 0
+  },
+  {
+    "global index": "SocialiQA_13810",
+    "flip": 0
+  },
+  {
+    "global index": "SocialiQA_22095",
+    "flip": 0
+  },
+  {
+    "global index": "SocialiQA_26846",
+    "flip": 0
+  },
+  {
+    "global index": "SocialiQA_7839",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-CausalReasoning_4526",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-ClozeTest_12894",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-ClozeTest_17965",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-ClozeTest_18766",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Entailment_19410",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Entailment_19567",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Entailment_522",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Entailment_767",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-QA_1408",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-QA_3137",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-QA_4046",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-QA_4102",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-QA_4160",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-RC_7725",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-RC_7738",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-RC_8531",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Wic_19695",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Wic_19738",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Wic_20079",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Wic_20189",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Wic_20253",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Wsc_20368",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Wsc_20370",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-cs-en_156",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-cs-en_246",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-cs-en_568",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-de-en_46",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-de-en_715",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-de-en_883",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-fi-en_222",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-fi-en_610",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-gu-en_116",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-gu-en_123",
+    "flip": 1
+  },
+  {
+    "global index": "WMT19-gu-en_191",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-gu-en_491",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-gu-en_968",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-kk-en_528",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-kk-en_826",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-lt-en_135",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-lt-en_269",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-lt-en_636",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-ru-en_222",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-zh-en_218",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-zh-en_252",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-zh-en_59",
+    "flip": 0
+  }
+]

--- a/src/data/routerMetrics/category_scores.json
+++ b/src/data/routerMetrics/category_scores.json
@@ -17658,5 +17658,937 @@
         }
       }
     }
+  },
+  "hybrid-router": {
+    "metrics": {
+      "easy": {
+        "accuracy": 96.2,
+        "cost": 0.0,
+        "robustness": 96.0
+      },
+      "medium": {
+        "accuracy": 67.7,
+        "cost": 0.0,
+        "robustness": 96.5
+      },
+      "hard": {
+        "accuracy": 25.7,
+        "cost": 0.0001,
+        "robustness": 98.2
+      },
+      "all": {
+        "accuracy": 71.4,
+        "cost": 0.0,
+        "robustness": 96.7
+      }
+    },
+    "categories": {
+      "Arts & recreation": {
+        "metrics": {
+          "easy": {
+            "accuracy": 94.3,
+            "cost": 0.0,
+            "robustness": 100.0
+          },
+          "medium": {
+            "accuracy": 57.3,
+            "cost": 0.0001,
+            "robustness": 100.0
+          },
+          "hard": {
+            "accuracy": 7.5,
+            "cost": 0.0001,
+            "robustness": 100.0
+          },
+          "all": {
+            "accuracy": 62.6,
+            "cost": 0.0,
+            "robustness": 100.0
+          }
+        },
+        "subcategories": {
+          "Arts": {
+            "metrics": {
+              "easy": {
+                "accuracy": 98.3,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 74.4,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 5.4,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 58.4,
+                "cost": 0.0,
+                "robustness": 100.0
+              }
+            }
+          },
+          "Music": {
+            "metrics": {
+              "easy": {
+                "accuracy": 96.0,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 50.9,
+                "cost": 0.0001,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 12.0,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 65.4,
+                "cost": 0.0,
+                "robustness": 100.0
+              }
+            }
+          },
+          "Sports, games and entertainment": {
+            "metrics": {
+              "easy": {
+                "accuracy": 91.4,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 58.0,
+                "cost": 0.0001,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 7.6,
+                "cost": 0.0001,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 62.4,
+                "cost": 0.0001,
+                "robustness": 100.0
+              }
+            }
+          }
+        }
+      },
+      "Computer science, information, and general works": {
+        "metrics": {
+          "easy": {
+            "accuracy": 97.5,
+            "cost": 0.0,
+            "robustness": 92.3
+          },
+          "medium": {
+            "accuracy": 80.3,
+            "cost": 0.0,
+            "robustness": 100.0
+          },
+          "hard": {
+            "accuracy": 33.5,
+            "cost": 0.0002,
+            "robustness": 100.0
+          },
+          "all": {
+            "accuracy": 80.6,
+            "cost": 0.0001,
+            "robustness": 96.8
+          }
+        },
+        "subcategories": {
+          "Computer science, knowledge, and systems": {
+            "metrics": {
+              "easy": {
+                "accuracy": 98.6,
+                "cost": 0.0,
+                "robustness": 84.6
+              },
+              "medium": {
+                "accuracy": 82.8,
+                "cost": 0.0001,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 37.8,
+                "cost": 0.0002,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 80.0,
+                "cost": 0.0001,
+                "robustness": 95.3
+              }
+            }
+          },
+          "Library and information sciences": {
+            "metrics": {
+              "easy": {
+                "accuracy": 96.0,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 69.4,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 8.3,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 82.3,
+                "cost": 0.0,
+                "robustness": 100.0
+              }
+            }
+          }
+        }
+      },
+      "History": {
+        "metrics": {
+          "easy": {
+            "accuracy": 96.5,
+            "cost": 0.0,
+            "robustness": 95.7
+          },
+          "medium": {
+            "accuracy": 62.1,
+            "cost": 0.0,
+            "robustness": 83.3
+          },
+          "hard": {
+            "accuracy": 9.4,
+            "cost": 0.0,
+            "robustness": 100.0
+          },
+          "all": {
+            "accuracy": 69.3,
+            "cost": 0.0,
+            "robustness": 94.9
+          }
+        },
+        "subcategories": {
+          "Biography and genealogy": {
+            "metrics": {
+              "easy": {
+                "accuracy": 92.9,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 66.7,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "hard": {
+                "accuracy": 100.0,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 88.5,
+                "cost": 0.0,
+                "robustness": 100.0
+              }
+            }
+          },
+          "Geography": {
+            "metrics": {
+              "easy": {
+                "accuracy": 96.3,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 48.3,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 25.0,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 81.3,
+                "cost": 0.0,
+                "robustness": 100.0
+              }
+            }
+          },
+          "History": {
+            "metrics": {
+              "easy": {
+                "accuracy": 97.3,
+                "cost": 0.0,
+                "robustness": 90.9
+              },
+              "medium": {
+                "accuracy": 64.7,
+                "cost": 0.0,
+                "robustness": 80.0
+              },
+              "hard": {
+                "accuracy": 7.4,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 63.7,
+                "cost": 0.0,
+                "robustness": 92.3
+              }
+            }
+          }
+        }
+      },
+      "Language": {
+        "metrics": {
+          "easy": {
+            "accuracy": 91.4,
+            "cost": 0.0,
+            "robustness": 100.0
+          },
+          "medium": {
+            "accuracy": 50.3,
+            "cost": 0.0,
+            "robustness": 100.0
+          },
+          "hard": {
+            "accuracy": 48.6,
+            "cost": 0.0,
+            "robustness": 96.0
+          },
+          "all": {
+            "accuracy": 61.8,
+            "cost": 0.0,
+            "robustness": 97.8
+          }
+        },
+        "subcategories": {
+          "Language": {
+            "metrics": {
+              "easy": {
+                "accuracy": 91.4,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 50.3,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 48.6,
+                "cost": 0.0,
+                "robustness": 96.0
+              },
+              "all": {
+                "accuracy": 61.8,
+                "cost": 0.0,
+                "robustness": 97.8
+              }
+            }
+          }
+        }
+      },
+      "Literature": {
+        "metrics": {
+          "easy": {
+            "accuracy": 96.9,
+            "cost": 0.0,
+            "robustness": 100.0
+          },
+          "medium": {
+            "accuracy": 65.0,
+            "cost": 0.0,
+            "robustness": 100.0
+          },
+          "hard": {
+            "accuracy": 28.7,
+            "cost": 0.0001,
+            "robustness": 100.0
+          },
+          "all": {
+            "accuracy": 43.2,
+            "cost": 0.0,
+            "robustness": 100.0
+          }
+        },
+        "subcategories": {
+          "Literature, rhetoric and criticism": {
+            "metrics": {
+              "easy": {
+                "accuracy": 96.9,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 65.0,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 28.7,
+                "cost": 0.0001,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 43.2,
+                "cost": 0.0,
+                "robustness": 100.0
+              }
+            }
+          }
+        }
+      },
+      "Philosophy and psychology": {
+        "metrics": {
+          "easy": {
+            "accuracy": 96.3,
+            "cost": 0.0,
+            "robustness": 96.3
+          },
+          "medium": {
+            "accuracy": 62.1,
+            "cost": 0.0,
+            "robustness": 80.0
+          },
+          "hard": {
+            "accuracy": 14.8,
+            "cost": 0.0,
+            "robustness": 100.0
+          },
+          "all": {
+            "accuracy": 76.6,
+            "cost": 0.0,
+            "robustness": 93.2
+          }
+        },
+        "subcategories": {
+          "Ethics": {
+            "metrics": {
+              "easy": {
+                "accuracy": 94.6,
+                "cost": 0.0,
+                "robustness": 92.9
+              },
+              "medium": {
+                "accuracy": 37.6,
+                "cost": 0.0,
+                "robustness": 60.0
+              },
+              "hard": {
+                "accuracy": 7.7,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 73.5,
+                "cost": 0.0,
+                "robustness": 85.7
+              }
+            }
+          },
+          "Philosophical logic": {
+            "metrics": {
+              "easy": {
+                "accuracy": 100.0,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 84.2,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 80.0,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 93.5,
+                "cost": 0.0,
+                "robustness": 100.0
+              }
+            }
+          },
+          "Philosophy": {
+            "metrics": {
+              "easy": {
+                "accuracy": 94.6,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 67.5,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 8.9,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 54.1,
+                "cost": 0.0,
+                "robustness": 100.0
+              }
+            }
+          },
+          "Psychology": {
+            "metrics": {
+              "easy": {
+                "accuracy": 97.5,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 83.3,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "hard": {
+                "accuracy": 16.7,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 86.1,
+                "cost": 0.0,
+                "robustness": 100.0
+              }
+            }
+          }
+        }
+      },
+      "Science": {
+        "metrics": {
+          "easy": {
+            "accuracy": 97.9,
+            "cost": 0.0,
+            "robustness": 97.4
+          },
+          "medium": {
+            "accuracy": 75.9,
+            "cost": 0.0,
+            "robustness": 100.0
+          },
+          "hard": {
+            "accuracy": 21.1,
+            "cost": 0.0001,
+            "robustness": 88.9
+          },
+          "all": {
+            "accuracy": 80.5,
+            "cost": 0.0,
+            "robustness": 97.1
+          }
+        },
+        "subcategories": {
+          "Animals (Zoology)": {
+            "metrics": {
+              "easy": {
+                "accuracy": 95.0,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 80.0,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "hard": {
+                "accuracy": 0,
+                "cost": 0,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 92.0,
+                "cost": 0.0,
+                "robustness": 100.0
+              }
+            }
+          },
+          "Biology": {
+            "metrics": {
+              "easy": {
+                "accuracy": 98.3,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 64.7,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "hard": {
+                "accuracy": 11.1,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 88.8,
+                "cost": 0.0,
+                "robustness": 100.0
+              }
+            }
+          },
+          "Chemistry": {
+            "metrics": {
+              "easy": {
+                "accuracy": 97.7,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 82.4,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 23.1,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 81.1,
+                "cost": 0.0,
+                "robustness": 100.0
+              }
+            }
+          },
+          "Earth sciences and geology": {
+            "metrics": {
+              "easy": {
+                "accuracy": 97.7,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 72.9,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 0.0,
+                "cost": 0.0,
+                "robustness": 0.0
+              },
+              "all": {
+                "accuracy": 89.4,
+                "cost": 0.0,
+                "robustness": 93.3
+              }
+            }
+          },
+          "Mathematics": {
+            "metrics": {
+              "easy": {
+                "accuracy": 99.2,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 79.6,
+                "cost": 0.0001,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 37.1,
+                "cost": 0.0002,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 81.9,
+                "cost": 0.0001,
+                "robustness": 100.0
+              }
+            }
+          },
+          "Physics": {
+            "metrics": {
+              "easy": {
+                "accuracy": 95.5,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 78.6,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 27.3,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 80.4,
+                "cost": 0.0,
+                "robustness": 100.0
+              }
+            }
+          },
+          "Science": {
+            "metrics": {
+              "easy": {
+                "accuracy": 93.3,
+                "cost": 0.0,
+                "robustness": 80.0
+              },
+              "medium": {
+                "accuracy": 40.0,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "hard": {
+                "accuracy": 1.7,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 34.2,
+                "cost": 0.0,
+                "robustness": 87.5
+              }
+            }
+          }
+        }
+      },
+      "Social Science": {
+        "metrics": {
+          "easy": {
+            "accuracy": 95.3,
+            "cost": 0.0,
+            "robustness": 100.0
+          },
+          "medium": {
+            "accuracy": 62.5,
+            "cost": 0.0,
+            "robustness": 100.0
+          },
+          "hard": {
+            "accuracy": 7.4,
+            "cost": 0.0001,
+            "robustness": 100.0
+          },
+          "all": {
+            "accuracy": 64.7,
+            "cost": 0.0,
+            "robustness": 100.0
+          }
+        },
+        "subcategories": {
+          "Economics": {
+            "metrics": {
+              "easy": {
+                "accuracy": 97.3,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 68.7,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 6.2,
+                "cost": 0.0001,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 69.2,
+                "cost": 0.0,
+                "robustness": 100.0
+              }
+            }
+          },
+          "Law": {
+            "metrics": {
+              "easy": {
+                "accuracy": 90.8,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 60.3,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 10.0,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 63.3,
+                "cost": 0.0,
+                "robustness": 100.0
+              }
+            }
+          },
+          "Social problems": {
+            "metrics": {
+              "easy": {
+                "accuracy": 93.6,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 22.2,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "hard": {
+                "accuracy": 20.0,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 77.0,
+                "cost": 0.0,
+                "robustness": 100.0
+              }
+            }
+          },
+          "Social sciences, sociology, and anthropology": {
+            "metrics": {
+              "easy": {
+                "accuracy": 100.0,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "medium": {
+                "accuracy": 33.3,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 5.9,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 20.0,
+                "cost": 0.0,
+                "robustness": 100.0
+              }
+            }
+          }
+        }
+      },
+      "Technology": {
+        "metrics": {
+          "easy": {
+            "accuracy": 95.5,
+            "cost": 0.0,
+            "robustness": 93.0
+          },
+          "medium": {
+            "accuracy": 67.6,
+            "cost": 0.0,
+            "robustness": 95.2
+          },
+          "hard": {
+            "accuracy": 17.8,
+            "cost": 0.0,
+            "robustness": 100.0
+          },
+          "all": {
+            "accuracy": 78.4,
+            "cost": 0.0,
+            "robustness": 94.4
+          }
+        },
+        "subcategories": {
+          "Engineering": {
+            "metrics": {
+              "easy": {
+                "accuracy": 96.0,
+                "cost": 0.0,
+                "robustness": 80.0
+              },
+              "medium": {
+                "accuracy": 80.8,
+                "cost": 0.0001,
+                "robustness": 92.3
+              },
+              "hard": {
+                "accuracy": 35.7,
+                "cost": 0.0001,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 80.9,
+                "cost": 0.0001,
+                "robustness": 89.5
+              }
+            }
+          },
+          "Management and public relations": {
+            "metrics": {
+              "easy": {
+                "accuracy": 100.0,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 63.6,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 0.0,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 91.8,
+                "cost": 0.0,
+                "robustness": 100.0
+              }
+            }
+          },
+          "Medicine and health": {
+            "metrics": {
+              "easy": {
+                "accuracy": 95.0,
+                "cost": 0.0,
+                "robustness": 94.1
+              },
+              "medium": {
+                "accuracy": 58.7,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 11.5,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 76.6,
+                "cost": 0.0,
+                "robustness": 95.7
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/src/data/routerMetrics/leaderboard.json
+++ b/src/data/routerMetrics/leaderboard.json
@@ -1,5 +1,16 @@
 [
   {
+    "Router Name": "vllm",
+    "Arena Score": 75.3,
+    "Optimal Selection Score": 16.81,
+    "Optimal Cost Score": 25.1,
+    "Optimal Acc. Score": 89.37,
+    "Robustness Score": 67.62,
+    "Latency Score": null,
+    "Accuracy": 77.18,
+    "Cost per 1k": 0.3
+  },
+  {
     "Router Name": "Sqwish Router",
     "Arena Score": 75.27,
     "Optimal Selection Score": 7.41,
@@ -44,17 +55,6 @@
     "Cost per 1k": 0.68
   },
   {
-    "Router Name": "vllm",
-    "Arena Score": 72.15,
-    "Optimal Selection Score": 20.77,
-    "Optimal Cost Score": 17.19,
-    "Optimal Acc. Score": 90.0,
-    "Robustness Score": 73.1,
-    "Latency Score": null,
-    "Accuracy": 73.19,
-    "Cost per 1k": 0.23
-  },
-  {
     "Router Name": "OrcaRouter-Adaptive",
     "Arena Score": 72.08,
     "Optimal Selection Score": null,
@@ -64,6 +64,17 @@
     "Latency Score": null,
     "Accuracy": 75.54,
     "Cost per 1k": 1.0
+  },
+  {
+    "Router Name": "Hybrid Router",
+    "Arena Score": 72.08,
+    "Optimal Selection Score": 89.87,
+    "Optimal Cost Score": 94.19,
+    "Optimal Acc. Score": 92.81,
+    "Robustness Score": 96.67,
+    "Latency Score": null,
+    "Accuracy": 71.38,
+    "Cost per 1k": 0.04
   },
   {
     "Router Name": "R2-Router",

--- a/src/data/routers.json
+++ b/src/data/routers.json
@@ -402,5 +402,17 @@
       "alibaba/qwen3-235b-a22b-instruct-2507",
       "alibaba/qwen3-30b-a3b-instruct-2507"
     ]
+  },
+  "Hybrid Router": {
+    "name": "Hybrid Router",
+    "affiliation": "@mikemao27",
+    "githubUrl": "https://github.com/mikemao27",
+    "type": "open-source",
+    "description": "Submitted by @mikemao27.",
+    "modelPool": [
+      "qwen/qwen3-235b-a22b-2507",
+      "qwen/qwen3-30b-a3b-instruct-2507",
+      "mistralai/ministral-3b-2512"
+    ]
   }
 }


### PR DESCRIPTION
Automated update of `src/data` from RouterArena
(commit eee8cda9c6a657fb11549d63c918f00180647ce5).

- `routerMetrics/leaderboard.json` — headline metrics (sourced from README)
- `routerMetrics/category_scores.json` — per-difficulty breakdown
- `flip_labels/*` — per-query robustness flips

Generated by `scripts/website/build_site_data.py`.