### PR TITLE
Sync leaderboard data from RouterArena

### DIFF
--- a/src/data/flip_labels/flip_labels_cross-router.json
+++ b/src/data/flip_labels/flip_labels_cross-router.json
@@ -1,0 +1,1682 @@
+[
+  {
+    "global index": "AIME_112",
+    "flip": 0
+  },
+  {
+    "global index": "AIME_58",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_12",
+    "flip": 1
+  },
+  {
+    "global index": "ArcMMLU_123",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_16",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_182",
+    "flip": 1
+  },
+  {
+    "global index": "ArcMMLU_230",
+    "flip": 1
+  },
+  {
+    "global index": "ArcMMLU_293",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_349",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_378",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_443",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_496",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_631",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_646",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_659",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_676",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_685",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_689",
+    "flip": 1
+  },
+  {
+    "global index": "ArcMMLU_702",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_713",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_98",
+    "flip": 0
+  },
+  {
+    "global index": "AsDiv_1165",
+    "flip": 0
+  },
+  {
+    "global index": "AsDiv_1347",
+    "flip": 0
+  },
+  {
+    "global index": "AsDiv_472",
+    "flip": 0
+  },
+  {
+    "global index": "AsDiv_733",
+    "flip": 0
+  },
+  {
+    "global index": "ChessInstruct_0",
+    "flip": 0
+  },
+  {
+    "global index": "ChessInstruct_107",
+    "flip": 0
+  },
+  {
+    "global index": "ChessInstruct_144",
+    "flip": 0
+  },
+  {
+    "global index": "ChessInstruct_42",
+    "flip": 0
+  },
+  {
+    "global index": "ChessInstruct_58",
+    "flip": 0
+  },
+  {
+    "global index": "ChessInstruct_71",
+    "flip": 0
+  },
+  {
+    "global index": "ChessInstruct_84",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_commonsense_28",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_commonsense_51",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_commonsense_6",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_commonsense_62",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_commonsense_70",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_commonsense_85",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_commonsense_90",
+    "flip": 1
+  },
+  {
+    "global index": "Ethics_deontology_0",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_deontology_2",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_deontology_31",
+    "flip": 1
+  },
+  {
+    "global index": "Ethics_deontology_32",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_deontology_56",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_justice_1",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_justice_45",
+    "flip": 1
+  },
+  {
+    "global index": "Ethics_justice_76",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_justice_84",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_virtue_14",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_virtue_26",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_virtue_30",
+    "flip": 1
+  },
+  {
+    "global index": "Ethics_virtue_48",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_virtue_51",
+    "flip": 1
+  },
+  {
+    "global index": "FinQA_149",
+    "flip": 1
+  },
+  {
+    "global index": "FinQA_208",
+    "flip": 1
+  },
+  {
+    "global index": "FinQA_56",
+    "flip": 1
+  },
+  {
+    "global index": "FinQA_60",
+    "flip": 0
+  },
+  {
+    "global index": "GSM8K_43",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_1002",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_1094",
+    "flip": 0
+  },
+  {
+    "global index": "GeoBench_1102",
+    "flip": 0
+  },
+  {
+    "global index": "GeoBench_1113",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_124",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_1243",
+    "flip": 0
+  },
+  {
+    "global index": "GeoBench_30",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_502",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_526",
+    "flip": 0
+  },
+  {
+    "global index": "GeoBench_591",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_766",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_87",
+    "flip": 0
+  },
+  {
+    "global index": "GeoBench_915",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_944",
+    "flip": 0
+  },
+  {
+    "global index": "GeoBench_968",
+    "flip": 0
+  },
+  {
+    "global index": "GeoGraphyData_100k_27",
+    "flip": 1
+  },
+  {
+    "global index": "GeoGraphyData_100k_42",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_105",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_114",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_118",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_131",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_136",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_181",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_237",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_271",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_350",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_386",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_405",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_43",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_431",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_437",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_476",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_485",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_49",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_491",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_499",
+    "flip": 1
+  },
+  {
+    "global index": "MATH_108",
+    "flip": 0
+  },
+  {
+    "global index": "MATH_442",
+    "flip": 0
+  },
+  {
+    "global index": "MATH_53",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_biology_2808",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_biology_2912",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_biology_2980",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_biology_2985",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_biology_3188",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_biology_3215",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_biology_3225",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_business_226",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_business_294",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_business_378",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_business_430",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_business_503",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_business_507",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_business_6",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_business_784",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_chemistry_3796",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_chemistry_3837",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_chemistry_3974",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_chemistry_4067",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_chemistry_4407",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9086",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9110",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9136",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9138",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9149",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9200",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9212",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9239",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9264",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9285",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9289",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9414",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9415",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9430",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9452",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_computer science_9471",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9475",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_economics_5769",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_economics_5907",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_economics_5931",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_economics_5965",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_economics_6114",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_economics_6122",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_economics_6135",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_economics_6325",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_economics_6353",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10076",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10125",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10179",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10195",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10199",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10298",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10342",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10395",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10428",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10432",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10473",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10537",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10701",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_engineering_10823",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10864",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_health_4885",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_health_4973",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_health_5093",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_health_5144",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_health_5214",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_health_5215",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_health_5261",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_health_5473",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_health_5514",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4486",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4490",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4497",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4509",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4517",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4523",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4605",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4629",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4638",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4717",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4749",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4752",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4774",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4810",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4833",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4836",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4841",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_law_1007",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_law_1031",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_law_1386",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_law_1462",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_law_1484",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_law_1518",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_law_1818",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_law_806",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_law_899",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_math_6429",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_math_6526",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_math_6623",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_math_6848",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_math_7101",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_math_7249",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_math_7284",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_math_7451",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_math_7577",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_philosophy_9510",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_philosophy_9536",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_philosophy_9663",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_philosophy_9672",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_philosophy_9943",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_physics_7773",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_physics_7887",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_physics_7893",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_physics_8888",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_physics_9017",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_psychology_2005",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_psychology_2186",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_psychology_2329",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_psychology_2406",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_psychology_2420",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_psychology_2450",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_psychology_2457",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_psychology_2524",
+    "flip": 1
+  },
+  {
+    "global index": "MMLU_formal_logic_121",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_formal_logic_16",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_formal_logic_32",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_formal_logic_63",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_formal_logic_7",
+    "flip": 1
+  },
+  {
+    "global index": "MMLU_formal_logic_70",
+    "flip": 1
+  },
+  {
+    "global index": "MMLU_formal_logic_85",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_management_4",
+    "flip": 1
+  },
+  {
+    "global index": "MMLU_management_41",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_management_77",
+    "flip": 1
+  },
+  {
+    "global index": "MMLU_management_91",
+    "flip": 1
+  },
+  {
+    "global index": "MMLU_management_93",
+    "flip": 1
+  },
+  {
+    "global index": "MathQA_158",
+    "flip": 1
+  },
+  {
+    "global index": "MathQA_1742",
+    "flip": 1
+  },
+  {
+    "global index": "MathQA_202",
+    "flip": 0
+  },
+  {
+    "global index": "MathQA_2092",
+    "flip": 0
+  },
+  {
+    "global index": "MathQA_2102",
+    "flip": 1
+  },
+  {
+    "global index": "MathQA_2851",
+    "flip": 1
+  },
+  {
+    "global index": "MathQA_827",
+    "flip": 0
+  },
+  {
+    "global index": "MathQA_84",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_1005",
+    "flip": 1
+  },
+  {
+    "global index": "MedMCQA_1054",
+    "flip": 1
+  },
+  {
+    "global index": "MedMCQA_1298",
+    "flip": 1
+  },
+  {
+    "global index": "MedMCQA_1309",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_1362",
+    "flip": 1
+  },
+  {
+    "global index": "MedMCQA_145",
+    "flip": 1
+  },
+  {
+    "global index": "MedMCQA_2010",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_2323",
+    "flip": 1
+  },
+  {
+    "global index": "MedMCQA_2366",
+    "flip": 1
+  },
+  {
+    "global index": "MedMCQA_2581",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_511",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_59",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_643",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_853",
+    "flip": 1
+  },
+  {
+    "global index": "MusicTheoryBench_126",
+    "flip": 1
+  },
+  {
+    "global index": "MusicTheoryBench_14",
+    "flip": 1
+  },
+  {
+    "global index": "MusicTheoryBench_147",
+    "flip": 1
+  },
+  {
+    "global index": "MusicTheoryBench_152",
+    "flip": 1
+  },
+  {
+    "global index": "MusicTheoryBench_188",
+    "flip": 0
+  },
+  {
+    "global index": "MusicTheoryBench_189",
+    "flip": 1
+  },
+  {
+    "global index": "MusicTheoryBench_240",
+    "flip": 0
+  },
+  {
+    "global index": "MusicTheoryBench_33",
+    "flip": 1
+  },
+  {
+    "global index": "MusicTheoryBench_337",
+    "flip": 1
+  },
+  {
+    "global index": "MusicTheoryBench_340",
+    "flip": 0
+  },
+  {
+    "global index": "MusicTheoryBench_70",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_131",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_1683",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_2474",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_2820",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_3282",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_4102",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_4128",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_4347",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_4540",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_5022",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_5259",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_533",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_5894",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_6829",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_7678",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_7964",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_8215",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_8598",
+    "flip": 0
+  },
+  {
+    "global index": "NarrativeQA_927",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Animals_2545",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Animals_262",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Art_1429",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Celebrities_1078",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Celebrities_1456",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Celebrities_3577",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Celebrities_3968",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_1178",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_1807",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_1957",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_2181",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_3404",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_3727",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_4019",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Geography_2099",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Geography_2346",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Geography_3880",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Geography_792",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_History_1162",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_History_2026",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_History_3712",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_History_3902",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Science & Nature_1175",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Science & Nature_1560",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Science & Nature_3716",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Science & Nature_476",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Sports_2289",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Vehicles_1173",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Vehicles_1419",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Vehicles_2519",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Vehicles_3234",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_0",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_154",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_18",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_238",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_250",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_337",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_362",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_437",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_510",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_520",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_575",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_582",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_588",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_610",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_63",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_643",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_687",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_722",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_73",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_755",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_8",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_81",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_854",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_905",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Fine Arts_1212",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Fine Arts_1702",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Fine Arts_828",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Fine Arts_865",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Geography_1023",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Geography_1555",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Geography_304",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_History_1084",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_History_1154",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_History_433",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_History_473",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_History_926",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Literature_1045",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Literature_1073",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Literature_1239",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Literature_1326",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Literature_1727",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Literature_1843",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Literature_386",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Literature_408",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Literature_475",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Literature_833",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Philosophy_1270",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Philosophy_499",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Philosophy_91",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Science_1360",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Science_1473",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Science_308",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Science_619",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Social Science_1847",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Social Science_2",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Social Science_77",
+    "flip": 0
+  },
+  {
+    "global index": "SocialiQA_13810",
+    "flip": 0
+  },
+  {
+    "global index": "SocialiQA_22095",
+    "flip": 0
+  },
+  {
+    "global index": "SocialiQA_26846",
+    "flip": 0
+  },
+  {
+    "global index": "SocialiQA_7839",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-CausalReasoning_4526",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-ClozeTest_12894",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-ClozeTest_17965",
+    "flip": 1
+  },
+  {
+    "global index": "SuperGLUE-ClozeTest_18766",
+    "flip": 1
+  },
+  {
+    "global index": "SuperGLUE-Entailment_19410",
+    "flip": 1
+  },
+  {
+    "global index": "SuperGLUE-Entailment_19567",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Entailment_522",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Entailment_767",
+    "flip": 1
+  },
+  {
+    "global index": "SuperGLUE-QA_1408",
+    "flip": 1
+  },
+  {
+    "global index": "SuperGLUE-QA_3137",
+    "flip": 1
+  },
+  {
+    "global index": "SuperGLUE-QA_4046",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-QA_4102",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-QA_4160",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-RC_7725",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-RC_7738",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-RC_8531",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Wic_19695",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Wic_19738",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Wic_20079",
+    "flip": 1
+  },
+  {
+    "global index": "SuperGLUE-Wic_20189",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Wic_20253",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Wsc_20368",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Wsc_20370",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-cs-en_156",
+    "flip": 1
+  },
+  {
+    "global index": "WMT19-cs-en_246",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-cs-en_568",
+    "flip": 1
+  },
+  {
+    "global index": "WMT19-de-en_46",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-de-en_715",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-de-en_883",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-fi-en_222",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-fi-en_610",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-gu-en_116",
+    "flip": 1
+  },
+  {
+    "global index": "WMT19-gu-en_123",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-gu-en_191",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-gu-en_491",
+    "flip": 1
+  },
+  {
+    "global index": "WMT19-gu-en_968",
+    "flip": 1
+  },
+  {
+    "global index": "WMT19-kk-en_528",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-kk-en_826",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-lt-en_135",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-lt-en_269",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-lt-en_636",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-ru-en_222",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-zh-en_218",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-zh-en_252",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-zh-en_59",
+    "flip": 0
+  }
+]

--- a/src/data/flip_labels/flip_labels_llm-router.json
+++ b/src/data/flip_labels/flip_labels_llm-router.json
@@ -1,0 +1,1682 @@
+[
+  {
+    "global index": "AIME_112",
+    "flip": 1
+  },
+  {
+    "global index": "AIME_58",
+    "flip": 1
+  },
+  {
+    "global index": "ArcMMLU_12",
+    "flip": 1
+  },
+  {
+    "global index": "ArcMMLU_123",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_16",
+    "flip": 1
+  },
+  {
+    "global index": "ArcMMLU_182",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_230",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_293",
+    "flip": 1
+  },
+  {
+    "global index": "ArcMMLU_349",
+    "flip": 1
+  },
+  {
+    "global index": "ArcMMLU_378",
+    "flip": 1
+  },
+  {
+    "global index": "ArcMMLU_443",
+    "flip": 1
+  },
+  {
+    "global index": "ArcMMLU_496",
+    "flip": 1
+  },
+  {
+    "global index": "ArcMMLU_631",
+    "flip": 1
+  },
+  {
+    "global index": "ArcMMLU_646",
+    "flip": 0
+  },
+  {
+    "global index": "ArcMMLU_659",
+    "flip": 1
+  },
+  {
+    "global index": "ArcMMLU_676",
+    "flip": 1
+  },
+  {
+    "global index": "ArcMMLU_685",
+    "flip": 1
+  },
+  {
+    "global index": "ArcMMLU_689",
+    "flip": 1
+  },
+  {
+    "global index": "ArcMMLU_702",
+    "flip": 1
+  },
+  {
+    "global index": "ArcMMLU_713",
+    "flip": 1
+  },
+  {
+    "global index": "ArcMMLU_98",
+    "flip": 1
+  },
+  {
+    "global index": "AsDiv_1165",
+    "flip": 1
+  },
+  {
+    "global index": "AsDiv_1347",
+    "flip": 1
+  },
+  {
+    "global index": "AsDiv_472",
+    "flip": 1
+  },
+  {
+    "global index": "AsDiv_733",
+    "flip": 1
+  },
+  {
+    "global index": "ChessInstruct_0",
+    "flip": 0
+  },
+  {
+    "global index": "ChessInstruct_107",
+    "flip": 0
+  },
+  {
+    "global index": "ChessInstruct_144",
+    "flip": 1
+  },
+  {
+    "global index": "ChessInstruct_42",
+    "flip": 0
+  },
+  {
+    "global index": "ChessInstruct_58",
+    "flip": 0
+  },
+  {
+    "global index": "ChessInstruct_71",
+    "flip": 0
+  },
+  {
+    "global index": "ChessInstruct_84",
+    "flip": 1
+  },
+  {
+    "global index": "Ethics_commonsense_28",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_commonsense_51",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_commonsense_6",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_commonsense_62",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_commonsense_70",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_commonsense_85",
+    "flip": 1
+  },
+  {
+    "global index": "Ethics_commonsense_90",
+    "flip": 1
+  },
+  {
+    "global index": "Ethics_deontology_0",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_deontology_2",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_deontology_31",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_deontology_32",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_deontology_56",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_justice_1",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_justice_45",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_justice_76",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_justice_84",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_virtue_14",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_virtue_26",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_virtue_30",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_virtue_48",
+    "flip": 0
+  },
+  {
+    "global index": "Ethics_virtue_51",
+    "flip": 0
+  },
+  {
+    "global index": "FinQA_149",
+    "flip": 1
+  },
+  {
+    "global index": "FinQA_208",
+    "flip": 0
+  },
+  {
+    "global index": "FinQA_56",
+    "flip": 1
+  },
+  {
+    "global index": "FinQA_60",
+    "flip": 1
+  },
+  {
+    "global index": "GSM8K_43",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_1002",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_1094",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_1102",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_1113",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_124",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_1243",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_30",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_502",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_526",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_591",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_766",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_87",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_915",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_944",
+    "flip": 1
+  },
+  {
+    "global index": "GeoBench_968",
+    "flip": 1
+  },
+  {
+    "global index": "GeoGraphyData_100k_27",
+    "flip": 1
+  },
+  {
+    "global index": "GeoGraphyData_100k_42",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_105",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_114",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_118",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_131",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_136",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_181",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_237",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_271",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_350",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_386",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_405",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_43",
+    "flip": 0
+  },
+  {
+    "global index": "LiveCodeBench_431",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_437",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_476",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_485",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_49",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_491",
+    "flip": 1
+  },
+  {
+    "global index": "LiveCodeBench_499",
+    "flip": 1
+  },
+  {
+    "global index": "MATH_108",
+    "flip": 1
+  },
+  {
+    "global index": "MATH_442",
+    "flip": 1
+  },
+  {
+    "global index": "MATH_53",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_biology_2808",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_biology_2912",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_biology_2980",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_biology_2985",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_biology_3188",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_biology_3215",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_biology_3225",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_business_226",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_business_294",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_business_378",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_business_430",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_business_503",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_business_507",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_business_6",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_business_784",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_chemistry_3796",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_chemistry_3837",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_chemistry_3974",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_chemistry_4067",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_chemistry_4407",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9086",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9110",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9136",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9138",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9149",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9200",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9212",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9239",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9264",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9285",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9289",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9414",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9415",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9430",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9452",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9471",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_computer science_9475",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_economics_5769",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_economics_5907",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_economics_5931",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_economics_5965",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_economics_6114",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_economics_6122",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_economics_6135",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_economics_6325",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_economics_6353",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10076",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10125",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10179",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10195",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10199",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10298",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10342",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10395",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10428",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10432",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10473",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10537",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10701",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10823",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_engineering_10864",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_health_4885",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_health_4973",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_health_5093",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_health_5144",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_health_5214",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_health_5215",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_health_5261",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_health_5473",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_health_5514",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4486",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4490",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4497",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4509",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4517",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4523",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4605",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4629",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4638",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4717",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4749",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4752",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_history_4774",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4810",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4833",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4836",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_history_4841",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_law_1007",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_law_1031",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_law_1386",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_law_1462",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_law_1484",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_law_1518",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_law_1818",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_law_806",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_law_899",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_math_6429",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_math_6526",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_math_6623",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_math_6848",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_math_7101",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_math_7249",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_math_7284",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_math_7451",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_math_7577",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_philosophy_9510",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_philosophy_9536",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_philosophy_9663",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_philosophy_9672",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_philosophy_9943",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_physics_7773",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_physics_7887",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_physics_7893",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_physics_8888",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_physics_9017",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_psychology_2005",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_psychology_2186",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_psychology_2329",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_psychology_2406",
+    "flip": 0
+  },
+  {
+    "global index": "MMLUPro_psychology_2420",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_psychology_2450",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_psychology_2457",
+    "flip": 1
+  },
+  {
+    "global index": "MMLUPro_psychology_2524",
+    "flip": 1
+  },
+  {
+    "global index": "MMLU_formal_logic_121",
+    "flip": 1
+  },
+  {
+    "global index": "MMLU_formal_logic_16",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_formal_logic_32",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_formal_logic_63",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_formal_logic_7",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_formal_logic_70",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_formal_logic_85",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_management_4",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_management_41",
+    "flip": 1
+  },
+  {
+    "global index": "MMLU_management_77",
+    "flip": 0
+  },
+  {
+    "global index": "MMLU_management_91",
+    "flip": 1
+  },
+  {
+    "global index": "MMLU_management_93",
+    "flip": 1
+  },
+  {
+    "global index": "MathQA_158",
+    "flip": 1
+  },
+  {
+    "global index": "MathQA_1742",
+    "flip": 1
+  },
+  {
+    "global index": "MathQA_202",
+    "flip": 1
+  },
+  {
+    "global index": "MathQA_2092",
+    "flip": 1
+  },
+  {
+    "global index": "MathQA_2102",
+    "flip": 1
+  },
+  {
+    "global index": "MathQA_2851",
+    "flip": 1
+  },
+  {
+    "global index": "MathQA_827",
+    "flip": 1
+  },
+  {
+    "global index": "MathQA_84",
+    "flip": 1
+  },
+  {
+    "global index": "MedMCQA_1005",
+    "flip": 1
+  },
+  {
+    "global index": "MedMCQA_1054",
+    "flip": 1
+  },
+  {
+    "global index": "MedMCQA_1298",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_1309",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_1362",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_145",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_2010",
+    "flip": 1
+  },
+  {
+    "global index": "MedMCQA_2323",
+    "flip": 1
+  },
+  {
+    "global index": "MedMCQA_2366",
+    "flip": 1
+  },
+  {
+    "global index": "MedMCQA_2581",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_511",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_59",
+    "flip": 1
+  },
+  {
+    "global index": "MedMCQA_643",
+    "flip": 0
+  },
+  {
+    "global index": "MedMCQA_853",
+    "flip": 1
+  },
+  {
+    "global index": "MusicTheoryBench_126",
+    "flip": 1
+  },
+  {
+    "global index": "MusicTheoryBench_14",
+    "flip": 1
+  },
+  {
+    "global index": "MusicTheoryBench_147",
+    "flip": 1
+  },
+  {
+    "global index": "MusicTheoryBench_152",
+    "flip": 1
+  },
+  {
+    "global index": "MusicTheoryBench_188",
+    "flip": 1
+  },
+  {
+    "global index": "MusicTheoryBench_189",
+    "flip": 1
+  },
+  {
+    "global index": "MusicTheoryBench_240",
+    "flip": 1
+  },
+  {
+    "global index": "MusicTheoryBench_33",
+    "flip": 0
+  },
+  {
+    "global index": "MusicTheoryBench_337",
+    "flip": 1
+  },
+  {
+    "global index": "MusicTheoryBench_340",
+    "flip": 1
+  },
+  {
+    "global index": "MusicTheoryBench_70",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_131",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_1683",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_2474",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_2820",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_3282",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_4102",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_4128",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_4347",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_4540",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_5022",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_5259",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_533",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_5894",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_6829",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_7678",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_7964",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_8215",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_8598",
+    "flip": 1
+  },
+  {
+    "global index": "NarrativeQA_927",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Animals_2545",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Animals_262",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Art_1429",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Celebrities_1078",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Celebrities_1456",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Celebrities_3577",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Celebrities_3968",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_1178",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_1807",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_1957",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_2181",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_3404",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_3727",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_General Knowledge_4019",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Geography_2099",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Geography_2346",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Geography_3880",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Geography_792",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_History_1162",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_History_2026",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_History_3712",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_History_3902",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Science & Nature_1175",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Science & Nature_1560",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Science & Nature_3716",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Science & Nature_476",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Sports_2289",
+    "flip": 0
+  },
+  {
+    "global index": "OpenTDB_Vehicles_1173",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Vehicles_1419",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Vehicles_2519",
+    "flip": 1
+  },
+  {
+    "global index": "OpenTDB_Vehicles_3234",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_0",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_154",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_18",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_238",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_250",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_337",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_362",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_437",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_510",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_520",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_575",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_582",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_588",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_610",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_63",
+    "flip": 0
+  },
+  {
+    "global index": "PubMedQA_643",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_687",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_722",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_73",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_755",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_8",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_81",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_854",
+    "flip": 1
+  },
+  {
+    "global index": "PubMedQA_905",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Fine Arts_1212",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Fine Arts_1702",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Fine Arts_828",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Fine Arts_865",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Geography_1023",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Geography_1555",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Geography_304",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_History_1084",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_History_1154",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_History_433",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_History_473",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_History_926",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Literature_1045",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Literature_1073",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Literature_1239",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Literature_1326",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Literature_1727",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Literature_1843",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Literature_386",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Literature_408",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Literature_475",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Literature_833",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Philosophy_1270",
+    "flip": 0
+  },
+  {
+    "global index": "QANTA_Philosophy_499",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Philosophy_91",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Science_1360",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Science_1473",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Science_308",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Science_619",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Social Science_1847",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Social Science_2",
+    "flip": 1
+  },
+  {
+    "global index": "QANTA_Social Science_77",
+    "flip": 1
+  },
+  {
+    "global index": "SocialiQA_13810",
+    "flip": 1
+  },
+  {
+    "global index": "SocialiQA_22095",
+    "flip": 0
+  },
+  {
+    "global index": "SocialiQA_26846",
+    "flip": 1
+  },
+  {
+    "global index": "SocialiQA_7839",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-CausalReasoning_4526",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-ClozeTest_12894",
+    "flip": 1
+  },
+  {
+    "global index": "SuperGLUE-ClozeTest_17965",
+    "flip": 1
+  },
+  {
+    "global index": "SuperGLUE-ClozeTest_18766",
+    "flip": 1
+  },
+  {
+    "global index": "SuperGLUE-Entailment_19410",
+    "flip": 1
+  },
+  {
+    "global index": "SuperGLUE-Entailment_19567",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Entailment_522",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Entailment_767",
+    "flip": 1
+  },
+  {
+    "global index": "SuperGLUE-QA_1408",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-QA_3137",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-QA_4046",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-QA_4102",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-QA_4160",
+    "flip": 1
+  },
+  {
+    "global index": "SuperGLUE-RC_7725",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-RC_7738",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-RC_8531",
+    "flip": 1
+  },
+  {
+    "global index": "SuperGLUE-Wic_19695",
+    "flip": 1
+  },
+  {
+    "global index": "SuperGLUE-Wic_19738",
+    "flip": 1
+  },
+  {
+    "global index": "SuperGLUE-Wic_20079",
+    "flip": 1
+  },
+  {
+    "global index": "SuperGLUE-Wic_20189",
+    "flip": 1
+  },
+  {
+    "global index": "SuperGLUE-Wic_20253",
+    "flip": 1
+  },
+  {
+    "global index": "SuperGLUE-Wsc_20368",
+    "flip": 0
+  },
+  {
+    "global index": "SuperGLUE-Wsc_20370",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-cs-en_156",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-cs-en_246",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-cs-en_568",
+    "flip": 1
+  },
+  {
+    "global index": "WMT19-de-en_46",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-de-en_715",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-de-en_883",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-fi-en_222",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-fi-en_610",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-gu-en_116",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-gu-en_123",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-gu-en_191",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-gu-en_491",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-gu-en_968",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-kk-en_528",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-kk-en_826",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-lt-en_135",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-lt-en_269",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-lt-en_636",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-ru-en_222",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-zh-en_218",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-zh-en_252",
+    "flip": 0
+  },
+  {
+    "global index": "WMT19-zh-en_59",
+    "flip": 0
+  }
+]

--- a/src/data/routerMetrics/category_scores.json
+++ b/src/data/routerMetrics/category_scores.json
@@ -18590,5 +18590,1869 @@
         }
       }
     }
+  },
+  "cross-router": {
+    "metrics": {
+      "easy": {
+        "accuracy": 96.1,
+        "cost": 0.0001,
+        "robustness": 59.1
+      },
+      "medium": {
+        "accuracy": 73.4,
+        "cost": 0.0003,
+        "robustness": 52.2
+      },
+      "hard": {
+        "accuracy": 35.0,
+        "cost": 0.0003,
+        "robustness": 66.1
+      },
+      "all": {
+        "accuracy": 75.2,
+        "cost": 0.0002,
+        "robustness": 59.0
+      }
+    },
+    "categories": {
+      "Arts & recreation": {
+        "metrics": {
+          "easy": {
+            "accuracy": 93.0,
+            "cost": 0.0001,
+            "robustness": 37.5
+          },
+          "medium": {
+            "accuracy": 62.0,
+            "cost": 0.0004,
+            "robustness": 63.6
+          },
+          "hard": {
+            "accuracy": 17.0,
+            "cost": 0.0004,
+            "robustness": 60.0
+          },
+          "all": {
+            "accuracy": 65.7,
+            "cost": 0.0003,
+            "robustness": 54.2
+          }
+        },
+        "subcategories": {
+          "Arts": {
+            "metrics": {
+              "easy": {
+                "accuracy": 98.3,
+                "cost": 0.0001,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 74.4,
+                "cost": 0.0002,
+                "robustness": 0.0
+              },
+              "hard": {
+                "accuracy": 19.6,
+                "cost": 0.0002,
+                "robustness": 50.0
+              },
+              "all": {
+                "accuracy": 63.6,
+                "cost": 0.0001,
+                "robustness": 40.0
+              }
+            }
+          },
+          "Music": {
+            "metrics": {
+              "easy": {
+                "accuracy": 96.0,
+                "cost": 0.0002,
+                "robustness": 20.0
+              },
+              "medium": {
+                "accuracy": 51.7,
+                "cost": 0.0007,
+                "robustness": 60.0
+              },
+              "hard": {
+                "accuracy": 12.0,
+                "cost": 0.0012,
+                "robustness": 0.0
+              },
+              "all": {
+                "accuracy": 65.8,
+                "cost": 0.0006,
+                "robustness": 36.4
+              }
+            }
+          },
+          "Sports, games and entertainment": {
+            "metrics": {
+              "easy": {
+                "accuracy": 88.6,
+                "cost": 0.0001,
+                "robustness": 50.0
+              },
+              "medium": {
+                "accuracy": 69.0,
+                "cost": 0.0002,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 16.7,
+                "cost": 0.0003,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 66.7,
+                "cost": 0.0002,
+                "robustness": 87.5
+              }
+            }
+          }
+        }
+      },
+      "Computer science, information, and general works": {
+        "metrics": {
+          "easy": {
+            "accuracy": 96.5,
+            "cost": 0.0002,
+            "robustness": 73.1
+          },
+          "medium": {
+            "accuracy": 77.7,
+            "cost": 0.0004,
+            "robustness": 47.6
+          },
+          "hard": {
+            "accuracy": 38.8,
+            "cost": 0.0007,
+            "robustness": 80.0
+          },
+          "all": {
+            "accuracy": 80.2,
+            "cost": 0.0003,
+            "robustness": 66.1
+          }
+        },
+        "subcategories": {
+          "Computer science, knowledge, and systems": {
+            "metrics": {
+              "easy": {
+                "accuracy": 97.1,
+                "cost": 0.0002,
+                "robustness": 69.2
+              },
+              "medium": {
+                "accuracy": 81.2,
+                "cost": 0.0005,
+                "robustness": 41.2
+              },
+              "hard": {
+                "accuracy": 44.0,
+                "cost": 0.0008,
+                "robustness": 76.9
+              },
+              "all": {
+                "accuracy": 80.1,
+                "cost": 0.0004,
+                "robustness": 60.5
+              }
+            }
+          },
+          "Library and information sciences": {
+            "metrics": {
+              "easy": {
+                "accuracy": 95.6,
+                "cost": 0.0001,
+                "robustness": 76.9
+              },
+              "medium": {
+                "accuracy": 62.4,
+                "cost": 0.0001,
+                "robustness": 75.0
+              },
+              "hard": {
+                "accuracy": 8.3,
+                "cost": 0.0001,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 80.6,
+                "cost": 0.0001,
+                "robustness": 78.9
+              }
+            }
+          }
+        }
+      },
+      "History": {
+        "metrics": {
+          "easy": {
+            "accuracy": 97.6,
+            "cost": 0.0001,
+            "robustness": 52.2
+          },
+          "medium": {
+            "accuracy": 80.8,
+            "cost": 0.0002,
+            "robustness": 16.7
+          },
+          "hard": {
+            "accuracy": 14.8,
+            "cost": 0.0002,
+            "robustness": 40.0
+          },
+          "all": {
+            "accuracy": 75.7,
+            "cost": 0.0002,
+            "robustness": 43.6
+          }
+        },
+        "subcategories": {
+          "Biography and genealogy": {
+            "metrics": {
+              "easy": {
+                "accuracy": 97.6,
+                "cost": 0.0,
+                "robustness": 0.0
+              },
+              "medium": {
+                "accuracy": 77.8,
+                "cost": 0.0001,
+                "robustness": 0
+              },
+              "hard": {
+                "accuracy": 0.0,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 92.3,
+                "cost": 0.0001,
+                "robustness": 0.0
+              }
+            }
+          },
+          "Geography": {
+            "metrics": {
+              "easy": {
+                "accuracy": 97.2,
+                "cost": 0.0,
+                "robustness": 62.5
+              },
+              "medium": {
+                "accuracy": 69.0,
+                "cost": 0.0001,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 33.3,
+                "cost": 0.0001,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 86.7,
+                "cost": 0.0001,
+                "robustness": 66.7
+              }
+            }
+          },
+          "History": {
+            "metrics": {
+              "easy": {
+                "accuracy": 97.8,
+                "cost": 0.0002,
+                "robustness": 63.6
+              },
+              "medium": {
+                "accuracy": 83.5,
+                "cost": 0.0003,
+                "robustness": 0.0
+              },
+              "hard": {
+                "accuracy": 13.2,
+                "cost": 0.0002,
+                "robustness": 40.0
+              },
+              "all": {
+                "accuracy": 70.7,
+                "cost": 0.0002,
+                "robustness": 42.3
+              }
+            }
+          }
+        }
+      },
+      "Language": {
+        "metrics": {
+          "easy": {
+            "accuracy": 91.9,
+            "cost": 0.0001,
+            "robustness": 72.7
+          },
+          "medium": {
+            "accuracy": 50.9,
+            "cost": 0.0002,
+            "robustness": 77.8
+          },
+          "hard": {
+            "accuracy": 65.0,
+            "cost": 0.0002,
+            "robustness": 72.0
+          },
+          "all": {
+            "accuracy": 69.6,
+            "cost": 0.0001,
+            "robustness": 73.3
+          }
+        },
+        "subcategories": {
+          "Language": {
+            "metrics": {
+              "easy": {
+                "accuracy": 91.9,
+                "cost": 0.0001,
+                "robustness": 72.7
+              },
+              "medium": {
+                "accuracy": 50.9,
+                "cost": 0.0002,
+                "robustness": 77.8
+              },
+              "hard": {
+                "accuracy": 65.0,
+                "cost": 0.0002,
+                "robustness": 72.0
+              },
+              "all": {
+                "accuracy": 69.6,
+                "cost": 0.0001,
+                "robustness": 73.3
+              }
+            }
+          }
+        }
+      },
+      "Literature": {
+        "metrics": {
+          "easy": {
+            "accuracy": 100.0,
+            "cost": 0.0001,
+            "robustness": 100.0
+          },
+          "medium": {
+            "accuracy": 76.5,
+            "cost": 0.0002,
+            "robustness": 100.0
+          },
+          "hard": {
+            "accuracy": 35.7,
+            "cost": 0.0002,
+            "robustness": 75.0
+          },
+          "all": {
+            "accuracy": 50.1,
+            "cost": 0.0002,
+            "robustness": 79.3
+          }
+        },
+        "subcategories": {
+          "Literature, rhetoric and criticism": {
+            "metrics": {
+              "easy": {
+                "accuracy": 100.0,
+                "cost": 0.0001,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 76.5,
+                "cost": 0.0002,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 35.7,
+                "cost": 0.0002,
+                "robustness": 75.0
+              },
+              "all": {
+                "accuracy": 50.1,
+                "cost": 0.0002,
+                "robustness": 79.3
+              }
+            }
+          }
+        }
+      },
+      "Philosophy and psychology": {
+        "metrics": {
+          "easy": {
+            "accuracy": 95.6,
+            "cost": 0.0001,
+            "robustness": 66.7
+          },
+          "medium": {
+            "accuracy": 70.1,
+            "cost": 0.0002,
+            "robustness": 90.0
+          },
+          "hard": {
+            "accuracy": 33.3,
+            "cost": 0.0002,
+            "robustness": 57.1
+          },
+          "all": {
+            "accuracy": 80.7,
+            "cost": 0.0002,
+            "robustness": 70.5
+          }
+        },
+        "subcategories": {
+          "Ethics": {
+            "metrics": {
+              "easy": {
+                "accuracy": 93.5,
+                "cost": 0.0001,
+                "robustness": 71.4
+              },
+              "medium": {
+                "accuracy": 45.9,
+                "cost": 0.0001,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 30.8,
+                "cost": 0.0001,
+                "robustness": 50.0
+              },
+              "all": {
+                "accuracy": 76.3,
+                "cost": 0.0001,
+                "robustness": 76.2
+              }
+            }
+          },
+          "Philosophical logic": {
+            "metrics": {
+              "easy": {
+                "accuracy": 100.0,
+                "cost": 0.0002,
+                "robustness": 50.0
+              },
+              "medium": {
+                "accuracy": 86.8,
+                "cost": 0.0002,
+                "robustness": 100.0
+              },
+              "hard": {
+                "accuracy": 80.0,
+                "cost": 0.0002,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 94.4,
+                "cost": 0.0002,
+                "robustness": 71.4
+              }
+            }
+          },
+          "Philosophy": {
+            "metrics": {
+              "easy": {
+                "accuracy": 94.6,
+                "cost": 0.0001,
+                "robustness": 33.3
+              },
+              "medium": {
+                "accuracy": 80.0,
+                "cost": 0.0002,
+                "robustness": 50.0
+              },
+              "hard": {
+                "accuracy": 35.6,
+                "cost": 0.0002,
+                "robustness": 66.7
+              },
+              "all": {
+                "accuracy": 68.0,
+                "cost": 0.0002,
+                "robustness": 50.0
+              }
+            }
+          },
+          "Psychology": {
+            "metrics": {
+              "easy": {
+                "accuracy": 96.7,
+                "cost": 0.0002,
+                "robustness": 83.3
+              },
+              "medium": {
+                "accuracy": 91.7,
+                "cost": 0.0002,
+                "robustness": 0
+              },
+              "hard": {
+                "accuracy": 16.7,
+                "cost": 0.0002,
+                "robustness": 50.0
+              },
+              "all": {
+                "accuracy": 87.7,
+                "cost": 0.0002,
+                "robustness": 75.0
+              }
+            }
+          }
+        }
+      },
+      "Science": {
+        "metrics": {
+          "easy": {
+            "accuracy": 98.6,
+            "cost": 0.0002,
+            "robustness": 51.3
+          },
+          "medium": {
+            "accuracy": 81.9,
+            "cost": 0.0003,
+            "robustness": 42.9
+          },
+          "hard": {
+            "accuracy": 28.9,
+            "cost": 0.0005,
+            "robustness": 66.7
+          },
+          "all": {
+            "accuracy": 83.8,
+            "cost": 0.0003,
+            "robustness": 50.7
+          }
+        },
+        "subcategories": {
+          "Animals (Zoology)": {
+            "metrics": {
+              "easy": {
+                "accuracy": 100.0,
+                "cost": 0.0001,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 60.0,
+                "cost": 0.0001,
+                "robustness": 0
+              },
+              "hard": {
+                "accuracy": 0,
+                "cost": 0,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 92.0,
+                "cost": 0.0001,
+                "robustness": 100.0
+              }
+            }
+          },
+          "Biology": {
+            "metrics": {
+              "easy": {
+                "accuracy": 100.0,
+                "cost": 0.0002,
+                "robustness": 0.0
+              },
+              "medium": {
+                "accuracy": 76.5,
+                "cost": 0.0003,
+                "robustness": 0
+              },
+              "hard": {
+                "accuracy": 33.3,
+                "cost": 0.0004,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 93.0,
+                "cost": 0.0002,
+                "robustness": 0.0
+              }
+            }
+          },
+          "Chemistry": {
+            "metrics": {
+              "easy": {
+                "accuracy": 100.0,
+                "cost": 0.0002,
+                "robustness": 33.3
+              },
+              "medium": {
+                "accuracy": 94.1,
+                "cost": 0.0004,
+                "robustness": 50.0
+              },
+              "hard": {
+                "accuracy": 23.1,
+                "cost": 0.0004,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 86.7,
+                "cost": 0.0003,
+                "robustness": 40.0
+              }
+            }
+          },
+          "Earth sciences and geology": {
+            "metrics": {
+              "easy": {
+                "accuracy": 97.3,
+                "cost": 0.0001,
+                "robustness": 62.5
+              },
+              "medium": {
+                "accuracy": 66.1,
+                "cost": 0.0002,
+                "robustness": 33.3
+              },
+              "hard": {
+                "accuracy": 23.1,
+                "cost": 0.0002,
+                "robustness": 0.0
+              },
+              "all": {
+                "accuracy": 88.8,
+                "cost": 0.0001,
+                "robustness": 46.7
+              }
+            }
+          },
+          "Mathematics": {
+            "metrics": {
+              "easy": {
+                "accuracy": 98.5,
+                "cost": 0.0002,
+                "robustness": 63.6
+              },
+              "medium": {
+                "accuracy": 84.0,
+                "cost": 0.0003,
+                "robustness": 45.5
+              },
+              "hard": {
+                "accuracy": 33.7,
+                "cost": 0.0009,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 82.9,
+                "cost": 0.0003,
+                "robustness": 63.0
+              }
+            }
+          },
+          "Physics": {
+            "metrics": {
+              "easy": {
+                "accuracy": 100.0,
+                "cost": 0.0002,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 90.5,
+                "cost": 0.0003,
+                "robustness": 50.0
+              },
+              "hard": {
+                "accuracy": 45.5,
+                "cost": 0.0003,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 89.7,
+                "cost": 0.0003,
+                "robustness": 80.0
+              }
+            }
+          },
+          "Science": {
+            "metrics": {
+              "easy": {
+                "accuracy": 100.0,
+                "cost": 0.0001,
+                "robustness": 40.0
+              },
+              "medium": {
+                "accuracy": 76.0,
+                "cost": 0.0001,
+                "robustness": 0
+              },
+              "hard": {
+                "accuracy": 20.3,
+                "cost": 0.0002,
+                "robustness": 33.3
+              },
+              "all": {
+                "accuracy": 53.5,
+                "cost": 0.0001,
+                "robustness": 37.5
+              }
+            }
+          }
+        }
+      },
+      "Social Science": {
+        "metrics": {
+          "easy": {
+            "accuracy": 96.3,
+            "cost": 0.0002,
+            "robustness": 55.6
+          },
+          "medium": {
+            "accuracy": 74.7,
+            "cost": 0.0005,
+            "robustness": 33.3
+          },
+          "hard": {
+            "accuracy": 16.1,
+            "cost": 0.0004,
+            "robustness": 42.9
+          },
+          "all": {
+            "accuracy": 71.4,
+            "cost": 0.0003,
+            "robustness": 45.9
+          }
+        },
+        "subcategories": {
+          "Economics": {
+            "metrics": {
+              "easy": {
+                "accuracy": 97.8,
+                "cost": 0.0002,
+                "robustness": 33.3
+              },
+              "medium": {
+                "accuracy": 79.8,
+                "cost": 0.0004,
+                "robustness": 33.3
+              },
+              "hard": {
+                "accuracy": 16.2,
+                "cost": 0.0004,
+                "robustness": 0.0
+              },
+              "all": {
+                "accuracy": 75.6,
+                "cost": 0.0003,
+                "robustness": 28.6
+              }
+            }
+          },
+          "Law": {
+            "metrics": {
+              "easy": {
+                "accuracy": 90.8,
+                "cost": 0.0004,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 68.3,
+                "cost": 0.0006,
+                "robustness": 25.0
+              },
+              "hard": {
+                "accuracy": 20.0,
+                "cost": 0.0006,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 68.4,
+                "cost": 0.0005,
+                "robustness": 66.7
+              }
+            }
+          },
+          "Social problems": {
+            "metrics": {
+              "easy": {
+                "accuracy": 97.9,
+                "cost": 0.0001,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 22.2,
+                "cost": 0.0001,
+                "robustness": 0
+              },
+              "hard": {
+                "accuracy": 0.0,
+                "cost": 0.0001,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 78.7,
+                "cost": 0.0001,
+                "robustness": 100.0
+              }
+            }
+          },
+          "Social sciences, sociology, and anthropology": {
+            "metrics": {
+              "easy": {
+                "accuracy": 100.0,
+                "cost": 0.0001,
+                "robustness": 0
+              },
+              "medium": {
+                "accuracy": 77.8,
+                "cost": 0.0002,
+                "robustness": 50.0
+              },
+              "hard": {
+                "accuracy": 14.7,
+                "cost": 0.0002,
+                "robustness": 0.0
+              },
+              "all": {
+                "accuracy": 40.0,
+                "cost": 0.0002,
+                "robustness": 33.3
+              }
+            }
+          }
+        }
+      },
+      "Technology": {
+        "metrics": {
+          "easy": {
+            "accuracy": 94.5,
+            "cost": 0.0002,
+            "robustness": 55.8
+          },
+          "medium": {
+            "accuracy": 72.9,
+            "cost": 0.0003,
+            "robustness": 47.6
+          },
+          "hard": {
+            "accuracy": 27.4,
+            "cost": 0.0004,
+            "robustness": 57.1
+          },
+          "all": {
+            "accuracy": 80.5,
+            "cost": 0.0002,
+            "robustness": 53.5
+          }
+        },
+        "subcategories": {
+          "Engineering": {
+            "metrics": {
+              "easy": {
+                "accuracy": 97.6,
+                "cost": 0.0002,
+                "robustness": 80.0
+              },
+              "medium": {
+                "accuracy": 86.8,
+                "cost": 0.0005,
+                "robustness": 61.5
+              },
+              "hard": {
+                "accuracy": 59.5,
+                "cost": 0.0007,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 87.5,
+                "cost": 0.0004,
+                "robustness": 68.4
+              }
+            }
+          },
+          "Management and public relations": {
+            "metrics": {
+              "easy": {
+                "accuracy": 100.0,
+                "cost": 0.0001,
+                "robustness": 25.0
+              },
+              "medium": {
+                "accuracy": 63.6,
+                "cost": 0.0001,
+                "robustness": 0.0
+              },
+              "hard": {
+                "accuracy": 0.0,
+                "cost": 0.0001,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 91.8,
+                "cost": 0.0001,
+                "robustness": 20.0
+              }
+            }
+          },
+          "Medicine and health": {
+            "metrics": {
+              "easy": {
+                "accuracy": 93.4,
+                "cost": 0.0001,
+                "robustness": 55.9
+              },
+              "medium": {
+                "accuracy": 63.6,
+                "cost": 0.0002,
+                "robustness": 28.6
+              },
+              "hard": {
+                "accuracy": 15.9,
+                "cost": 0.0003,
+                "robustness": 50.0
+              },
+              "all": {
+                "accuracy": 77.3,
+                "cost": 0.0002,
+                "robustness": 51.1
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "llm-router": {
+    "metrics": {
+      "easy": {
+        "accuracy": 95.6,
+        "cost": 0.0001,
+        "robustness": 30.8
+      },
+      "medium": {
+        "accuracy": 69.1,
+        "cost": 0.0002,
+        "robustness": 23.9
+      },
+      "hard": {
+        "accuracy": 27.0,
+        "cost": 0.0002,
+        "robustness": 34.9
+      },
+      "all": {
+        "accuracy": 71.8,
+        "cost": 0.0001,
+        "robustness": 30.0
+      }
+    },
+    "categories": {
+      "Arts & recreation": {
+        "metrics": {
+          "easy": {
+            "accuracy": 92.6,
+            "cost": 0.0001,
+            "robustness": 37.5
+          },
+          "medium": {
+            "accuracy": 52.2,
+            "cost": 0.0003,
+            "robustness": 27.3
+          },
+          "hard": {
+            "accuracy": 10.2,
+            "cost": 0.0004,
+            "robustness": 20.0
+          },
+          "all": {
+            "accuracy": 60.6,
+            "cost": 0.0002,
+            "robustness": 29.2
+          }
+        },
+        "subcategories": {
+          "Arts": {
+            "metrics": {
+              "easy": {
+                "accuracy": 93.2,
+                "cost": 0.0,
+                "robustness": 0.0
+              },
+              "medium": {
+                "accuracy": 64.1,
+                "cost": 0.0001,
+                "robustness": 0.0
+              },
+              "hard": {
+                "accuracy": 8.9,
+                "cost": 0.0004,
+                "robustness": 0.0
+              },
+              "all": {
+                "accuracy": 55.2,
+                "cost": 0.0002,
+                "robustness": 0.0
+              }
+            }
+          },
+          "Music": {
+            "metrics": {
+              "easy": {
+                "accuracy": 97.0,
+                "cost": 0.0001,
+                "robustness": 20.0
+              },
+              "medium": {
+                "accuracy": 47.4,
+                "cost": 0.0005,
+                "robustness": 0.0
+              },
+              "hard": {
+                "accuracy": 12.0,
+                "cost": 0.0008,
+                "robustness": 0.0
+              },
+              "all": {
+                "accuracy": 64.2,
+                "cost": 0.0003,
+                "robustness": 9.1
+              }
+            }
+          },
+          "Sports, games and entertainment": {
+            "metrics": {
+              "easy": {
+                "accuracy": 89.3,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 53.0,
+                "cost": 0.0001,
+                "robustness": 75.0
+              },
+              "hard": {
+                "accuracy": 10.6,
+                "cost": 0.0003,
+                "robustness": 50.0
+              },
+              "all": {
+                "accuracy": 60.5,
+                "cost": 0.0001,
+                "robustness": 75.0
+              }
+            }
+          }
+        }
+      },
+      "Computer science, information, and general works": {
+        "metrics": {
+          "easy": {
+            "accuracy": 96.2,
+            "cost": 0.0001,
+            "robustness": 23.1
+          },
+          "medium": {
+            "accuracy": 76.6,
+            "cost": 0.0001,
+            "robustness": 14.3
+          },
+          "hard": {
+            "accuracy": 28.6,
+            "cost": 0.0001,
+            "robustness": 20.0
+          },
+          "all": {
+            "accuracy": 77.9,
+            "cost": 0.0001,
+            "robustness": 19.4
+          }
+        },
+        "subcategories": {
+          "Computer science, knowledge, and systems": {
+            "metrics": {
+              "easy": {
+                "accuracy": 96.9,
+                "cost": 0.0001,
+                "robustness": 23.1
+              },
+              "medium": {
+                "accuracy": 81.4,
+                "cost": 0.0001,
+                "robustness": 11.8
+              },
+              "hard": {
+                "accuracy": 31.1,
+                "cost": 0.0002,
+                "robustness": 23.1
+              },
+              "all": {
+                "accuracy": 77.4,
+                "cost": 0.0001,
+                "robustness": 18.6
+              }
+            }
+          },
+          "Library and information sciences": {
+            "metrics": {
+              "easy": {
+                "accuracy": 95.3,
+                "cost": 0.0001,
+                "robustness": 23.1
+              },
+              "medium": {
+                "accuracy": 55.3,
+                "cost": 0.0001,
+                "robustness": 25.0
+              },
+              "hard": {
+                "accuracy": 13.9,
+                "cost": 0.0001,
+                "robustness": 0.0
+              },
+              "all": {
+                "accuracy": 79.3,
+                "cost": 0.0001,
+                "robustness": 21.1
+              }
+            }
+          }
+        }
+      },
+      "History": {
+        "metrics": {
+          "easy": {
+            "accuracy": 96.8,
+            "cost": 0.0001,
+            "robustness": 34.8
+          },
+          "medium": {
+            "accuracy": 75.1,
+            "cost": 0.0002,
+            "robustness": 16.7
+          },
+          "hard": {
+            "accuracy": 17.4,
+            "cost": 0.0002,
+            "robustness": 10.0
+          },
+          "all": {
+            "accuracy": 74.4,
+            "cost": 0.0001,
+            "robustness": 25.6
+          }
+        },
+        "subcategories": {
+          "Biography and genealogy": {
+            "metrics": {
+              "easy": {
+                "accuracy": 97.6,
+                "cost": 0.0,
+                "robustness": 75.0
+              },
+              "medium": {
+                "accuracy": 77.8,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "hard": {
+                "accuracy": 100.0,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 94.2,
+                "cost": 0.0,
+                "robustness": 75.0
+              }
+            }
+          },
+          "Geography": {
+            "metrics": {
+              "easy": {
+                "accuracy": 96.3,
+                "cost": 0.0001,
+                "robustness": 12.5
+              },
+              "medium": {
+                "accuracy": 55.2,
+                "cost": 0.0001,
+                "robustness": 0.0
+              },
+              "hard": {
+                "accuracy": 25.0,
+                "cost": 0.0002,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 82.7,
+                "cost": 0.0001,
+                "robustness": 11.1
+              }
+            }
+          },
+          "History": {
+            "metrics": {
+              "easy": {
+                "accuracy": 96.9,
+                "cost": 0.0002,
+                "robustness": 36.4
+              },
+              "medium": {
+                "accuracy": 79.1,
+                "cost": 0.0002,
+                "robustness": 20.0
+              },
+              "hard": {
+                "accuracy": 16.2,
+                "cost": 0.0002,
+                "robustness": 10.0
+              },
+              "all": {
+                "accuracy": 69.9,
+                "cost": 0.0002,
+                "robustness": 23.1
+              }
+            }
+          }
+        }
+      },
+      "Language": {
+        "metrics": {
+          "easy": {
+            "accuracy": 88.5,
+            "cost": 0.0,
+            "robustness": 45.5
+          },
+          "medium": {
+            "accuracy": 48.5,
+            "cost": 0.0001,
+            "robustness": 66.7
+          },
+          "hard": {
+            "accuracy": 48.3,
+            "cost": 0.0,
+            "robustness": 84.0
+          },
+          "all": {
+            "accuracy": 60.3,
+            "cost": 0.0,
+            "robustness": 71.1
+          }
+        },
+        "subcategories": {
+          "Language": {
+            "metrics": {
+              "easy": {
+                "accuracy": 88.5,
+                "cost": 0.0,
+                "robustness": 45.5
+              },
+              "medium": {
+                "accuracy": 48.5,
+                "cost": 0.0001,
+                "robustness": 66.7
+              },
+              "hard": {
+                "accuracy": 48.3,
+                "cost": 0.0,
+                "robustness": 84.0
+              },
+              "all": {
+                "accuracy": 60.3,
+                "cost": 0.0,
+                "robustness": 71.1
+              }
+            }
+          }
+        }
+      },
+      "Literature": {
+        "metrics": {
+          "easy": {
+            "accuracy": 99.1,
+            "cost": 0.0,
+            "robustness": 0.0
+          },
+          "medium": {
+            "accuracy": 72.5,
+            "cost": 0.0001,
+            "robustness": 0.0
+          },
+          "hard": {
+            "accuracy": 31.9,
+            "cost": 0.0002,
+            "robustness": 0.0
+          },
+          "all": {
+            "accuracy": 46.7,
+            "cost": 0.0002,
+            "robustness": 0.0
+          }
+        },
+        "subcategories": {
+          "Literature, rhetoric and criticism": {
+            "metrics": {
+              "easy": {
+                "accuracy": 99.1,
+                "cost": 0.0,
+                "robustness": 0.0
+              },
+              "medium": {
+                "accuracy": 72.5,
+                "cost": 0.0001,
+                "robustness": 0.0
+              },
+              "hard": {
+                "accuracy": 31.9,
+                "cost": 0.0002,
+                "robustness": 0.0
+              },
+              "all": {
+                "accuracy": 46.7,
+                "cost": 0.0002,
+                "robustness": 0.0
+              }
+            }
+          }
+        }
+      },
+      "Philosophy and psychology": {
+        "metrics": {
+          "easy": {
+            "accuracy": 93.6,
+            "cost": 0.0,
+            "robustness": 85.2
+          },
+          "medium": {
+            "accuracy": 66.8,
+            "cost": 0.0,
+            "robustness": 70.0
+          },
+          "hard": {
+            "accuracy": 16.0,
+            "cost": 0.0002,
+            "robustness": 57.1
+          },
+          "all": {
+            "accuracy": 76.6,
+            "cost": 0.0001,
+            "robustness": 77.3
+          }
+        },
+        "subcategories": {
+          "Ethics": {
+            "metrics": {
+              "easy": {
+                "accuracy": 90.8,
+                "cost": 0.0,
+                "robustness": 92.9
+              },
+              "medium": {
+                "accuracy": 43.5,
+                "cost": 0.0,
+                "robustness": 80.0
+              },
+              "hard": {
+                "accuracy": 0.0,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 72.4,
+                "cost": 0.0,
+                "robustness": 90.5
+              }
+            }
+          },
+          "Philosophical logic": {
+            "metrics": {
+              "easy": {
+                "accuracy": 95.4,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 92.1,
+                "cost": 0.0,
+                "robustness": 66.7
+              },
+              "hard": {
+                "accuracy": 60.0,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 92.6,
+                "cost": 0.0,
+                "robustness": 85.7
+              }
+            }
+          },
+          "Philosophy": {
+            "metrics": {
+              "easy": {
+                "accuracy": 97.3,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "medium": {
+                "accuracy": 72.5,
+                "cost": 0.0001,
+                "robustness": 50.0
+              },
+              "hard": {
+                "accuracy": 17.8,
+                "cost": 0.0003,
+                "robustness": 33.3
+              },
+              "all": {
+                "accuracy": 59.8,
+                "cost": 0.0001,
+                "robustness": 62.5
+              }
+            }
+          },
+          "Psychology": {
+            "metrics": {
+              "easy": {
+                "accuracy": 95.9,
+                "cost": 0.0001,
+                "robustness": 50.0
+              },
+              "medium": {
+                "accuracy": 83.3,
+                "cost": 0.0001,
+                "robustness": 0
+              },
+              "hard": {
+                "accuracy": 11.1,
+                "cost": 0.0001,
+                "robustness": 50.0
+              },
+              "all": {
+                "accuracy": 84.5,
+                "cost": 0.0001,
+                "robustness": 50.0
+              }
+            }
+          }
+        }
+      },
+      "Science": {
+        "metrics": {
+          "easy": {
+            "accuracy": 98.6,
+            "cost": 0.0001,
+            "robustness": 7.7
+          },
+          "medium": {
+            "accuracy": 79.4,
+            "cost": 0.0002,
+            "robustness": 0.0
+          },
+          "hard": {
+            "accuracy": 18.0,
+            "cost": 0.0005,
+            "robustness": 0.0
+          },
+          "all": {
+            "accuracy": 81.5,
+            "cost": 0.0002,
+            "robustness": 4.3
+          }
+        },
+        "subcategories": {
+          "Animals (Zoology)": {
+            "metrics": {
+              "easy": {
+                "accuracy": 95.0,
+                "cost": 0.0001,
+                "robustness": 50.0
+              },
+              "medium": {
+                "accuracy": 60.0,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "hard": {
+                "accuracy": 0,
+                "cost": 0,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 88.0,
+                "cost": 0.0001,
+                "robustness": 50.0
+              }
+            }
+          },
+          "Biology": {
+            "metrics": {
+              "easy": {
+                "accuracy": 99.1,
+                "cost": 0.0001,
+                "robustness": 14.3
+              },
+              "medium": {
+                "accuracy": 76.5,
+                "cost": 0.0002,
+                "robustness": 0
+              },
+              "hard": {
+                "accuracy": 22.2,
+                "cost": 0.0002,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 91.6,
+                "cost": 0.0001,
+                "robustness": 14.3
+              }
+            }
+          },
+          "Chemistry": {
+            "metrics": {
+              "easy": {
+                "accuracy": 95.3,
+                "cost": 0.0001,
+                "robustness": 0.0
+              },
+              "medium": {
+                "accuracy": 85.3,
+                "cost": 0.0001,
+                "robustness": 0.0
+              },
+              "hard": {
+                "accuracy": 23.1,
+                "cost": 0.0004,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 81.1,
+                "cost": 0.0001,
+                "robustness": 0.0
+              }
+            }
+          },
+          "Earth sciences and geology": {
+            "metrics": {
+              "easy": {
+                "accuracy": 99.6,
+                "cost": 0.0001,
+                "robustness": 0.0
+              },
+              "medium": {
+                "accuracy": 59.3,
+                "cost": 0.0001,
+                "robustness": 0.0
+              },
+              "hard": {
+                "accuracy": 23.1,
+                "cost": 0.0001,
+                "robustness": 0.0
+              },
+              "all": {
+                "accuracy": 89.4,
+                "cost": 0.0001,
+                "robustness": 0.0
+              }
+            }
+          },
+          "Mathematics": {
+            "metrics": {
+              "easy": {
+                "accuracy": 98.1,
+                "cost": 0.0001,
+                "robustness": 9.1
+              },
+              "medium": {
+                "accuracy": 83.6,
+                "cost": 0.0002,
+                "robustness": 0.0
+              },
+              "hard": {
+                "accuracy": 22.5,
+                "cost": 0.0008,
+                "robustness": 0.0
+              },
+              "all": {
+                "accuracy": 80.9,
+                "cost": 0.0002,
+                "robustness": 3.7
+              }
+            }
+          },
+          "Physics": {
+            "metrics": {
+              "easy": {
+                "accuracy": 97.7,
+                "cost": 0.0002,
+                "robustness": 0.0
+              },
+              "medium": {
+                "accuracy": 92.9,
+                "cost": 0.0002,
+                "robustness": 0.0
+              },
+              "hard": {
+                "accuracy": 45.5,
+                "cost": 0.0003,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 89.7,
+                "cost": 0.0002,
+                "robustness": 0.0
+              }
+            }
+          },
+          "Science": {
+            "metrics": {
+              "easy": {
+                "accuracy": 100.0,
+                "cost": 0.0001,
+                "robustness": 0.0
+              },
+              "medium": {
+                "accuracy": 60.0,
+                "cost": 0.0001,
+                "robustness": 0
+              },
+              "hard": {
+                "accuracy": 3.4,
+                "cost": 0.0002,
+                "robustness": 0.0
+              },
+              "all": {
+                "accuracy": 41.2,
+                "cost": 0.0001,
+                "robustness": 0.0
+              }
+            }
+          }
+        }
+      },
+      "Social Science": {
+        "metrics": {
+          "easy": {
+            "accuracy": 97.0,
+            "cost": 0.0001,
+            "robustness": 16.7
+          },
+          "medium": {
+            "accuracy": 67.6,
+            "cost": 0.0002,
+            "robustness": 41.7
+          },
+          "hard": {
+            "accuracy": 11.4,
+            "cost": 0.0002,
+            "robustness": 42.9
+          },
+          "all": {
+            "accuracy": 68.1,
+            "cost": 0.0001,
+            "robustness": 29.7
+          }
+        },
+        "subcategories": {
+          "Economics": {
+            "metrics": {
+              "easy": {
+                "accuracy": 97.3,
+                "cost": 0.0001,
+                "robustness": 8.3
+              },
+              "medium": {
+                "accuracy": 71.2,
+                "cost": 0.0002,
+                "robustness": 66.7
+              },
+              "hard": {
+                "accuracy": 8.8,
+                "cost": 0.0002,
+                "robustness": 33.3
+              },
+              "all": {
+                "accuracy": 70.7,
+                "cost": 0.0001,
+                "robustness": 28.6
+              }
+            }
+          },
+          "Law": {
+            "metrics": {
+              "easy": {
+                "accuracy": 95.4,
+                "cost": 0.0002,
+                "robustness": 33.3
+              },
+              "medium": {
+                "accuracy": 73.0,
+                "cost": 0.0002,
+                "robustness": 25.0
+              },
+              "hard": {
+                "accuracy": 23.3,
+                "cost": 0.0002,
+                "robustness": 50.0
+              },
+              "all": {
+                "accuracy": 72.8,
+                "cost": 0.0002,
+                "robustness": 33.3
+              }
+            }
+          },
+          "Social problems": {
+            "metrics": {
+              "easy": {
+                "accuracy": 97.9,
+                "cost": 0.0,
+                "robustness": 33.3
+              },
+              "medium": {
+                "accuracy": 0.0,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "hard": {
+                "accuracy": 20.0,
+                "cost": 0.0,
+                "robustness": 100.0
+              },
+              "all": {
+                "accuracy": 77.0,
+                "cost": 0.0,
+                "robustness": 50.0
+              }
+            }
+          },
+          "Social sciences, sociology, and anthropology": {
+            "metrics": {
+              "easy": {
+                "accuracy": 100.0,
+                "cost": 0.0001,
+                "robustness": 0
+              },
+              "medium": {
+                "accuracy": 50.0,
+                "cost": 0.0001,
+                "robustness": 0.0
+              },
+              "hard": {
+                "accuracy": 5.9,
+                "cost": 0.0001,
+                "robustness": 0.0
+              },
+              "all": {
+                "accuracy": 25.5,
+                "cost": 0.0001,
+                "robustness": 0.0
+              }
+            }
+          }
+        }
+      },
+      "Technology": {
+        "metrics": {
+          "easy": {
+            "accuracy": 94.8,
+            "cost": 0.0001,
+            "robustness": 23.3
+          },
+          "medium": {
+            "accuracy": 67.4,
+            "cost": 0.0002,
+            "robustness": 9.5
+          },
+          "hard": {
+            "accuracy": 21.0,
+            "cost": 0.0002,
+            "robustness": 71.4
+          },
+          "all": {
+            "accuracy": 78.3,
+            "cost": 0.0002,
+            "robustness": 23.9
+          }
+        },
+        "subcategories": {
+          "Engineering": {
+            "metrics": {
+              "easy": {
+                "accuracy": 95.2,
+                "cost": 0.0001,
+                "robustness": 0.0
+              },
+              "medium": {
+                "accuracy": 84.4,
+                "cost": 0.0003,
+                "robustness": 7.7
+              },
+              "hard": {
+                "accuracy": 47.6,
+                "cost": 0.0005,
+                "robustness": 0.0
+              },
+              "all": {
+                "accuracy": 83.9,
+                "cost": 0.0003,
+                "robustness": 5.3
+              }
+            }
+          },
+          "Management and public relations": {
+            "metrics": {
+              "easy": {
+                "accuracy": 95.0,
+                "cost": 0.0,
+                "robustness": 50.0
+              },
+              "medium": {
+                "accuracy": 63.6,
+                "cost": 0.0,
+                "robustness": 0.0
+              },
+              "hard": {
+                "accuracy": 0.0,
+                "cost": 0.0,
+                "robustness": 0
+              },
+              "all": {
+                "accuracy": 87.7,
+                "cost": 0.0,
+                "robustness": 40.0
+              }
+            }
+          },
+          "Medicine and health": {
+            "metrics": {
+              "easy": {
+                "accuracy": 94.7,
+                "cost": 0.0001,
+                "robustness": 23.5
+              },
+              "medium": {
+                "accuracy": 55.8,
+                "cost": 0.0001,
+                "robustness": 14.3
+              },
+              "hard": {
+                "accuracy": 11.5,
+                "cost": 0.0001,
+                "robustness": 83.3
+              },
+              "all": {
+                "accuracy": 75.7,
+                "cost": 0.0001,
+                "robustness": 29.8
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/src/data/routerMetrics/leaderboard.json
+++ b/src/data/routerMetrics/leaderboard.json
@@ -33,6 +33,17 @@
     "Cost per 1k": 0.13
   },
   {
+    "Router Name": "Cross-Router",
+    "Arena Score": 73.71,
+    "Optimal Selection Score": 40.18,
+    "Optimal Cost Score": 44.03,
+    "Optimal Acc. Score": 89.58,
+    "Robustness Score": 59.05,
+    "Latency Score": null,
+    "Accuracy": 75.13,
+    "Cost per 1k": 0.26
+  },
+  {
     "Router Name": "Weave Router",
     "Arena Score": 72.82,
     "Optimal Selection Score": null,
@@ -86,6 +97,17 @@
     "Latency Score": null,
     "Accuracy": 71.23,
     "Cost per 1k": 0.06
+  },
+  {
+    "Router Name": "LLM Router",
+    "Arena Score": 71.26,
+    "Optimal Selection Score": 18.01,
+    "Optimal Cost Score": 20.46,
+    "Optimal Acc. Score": 89.13,
+    "Robustness Score": 30.0,
+    "Latency Score": null,
+    "Accuracy": 72.05,
+    "Cost per 1k": 0.2
   },
   {
     "Router Name": "azure",

--- a/src/data/routers.json
+++ b/src/data/routers.json
@@ -414,5 +414,31 @@
       "qwen/qwen3-30b-a3b-instruct-2507",
       "mistralai/ministral-3b-2512"
     ]
+  },
+  "Cross-Router": {
+    "name": "Cross-Router",
+    "affiliation": "@JiaHg",
+    "githubUrl": "https://github.com/JiaHg",
+    "type": "open-source",
+    "description": "Submitted by @JiaHg.",
+    "modelPool": [
+      "google/gemini-3.1-flash-lite",
+      "deepseek/deepseek-v4-flash",
+      "deepseek/deepseek-v4-pro"
+    ]
+  },
+  "LLM Router": {
+    "name": "LLM Router",
+    "affiliation": "@ypollak2",
+    "githubUrl": "https://github.com/ypollak2",
+    "type": "open-source",
+    "description": "Submitted by @ypollak2.",
+    "modelPool": [
+      "qwen/qwen3-235b-a22b-2507",
+      "qwen/qwen3-next-80b-a3b-instruct",
+      "Qwen/Qwen3-Coder-Next",
+      "google/gemini-3.1-flash-lite",
+      "deepseek/deepseek-v4-flash"
+    ]
   }
 }


### PR DESCRIPTION
Automated update of `src/data` from RouterArena
(commit c6990b01afdd523b96fb2be67f8b70f29e8c3d78).

- `routerMetrics/leaderboard.json` — headline metrics (sourced from README)
- `routerMetrics/category_scores.json` — per-difficulty breakdown
- `flip_labels/*` — per-query robustness flips

Generated by `scripts/website/build_site_data.py`.